### PR TITLE
Fixing a 'withArgs' and 'atLeast' issue with mock.js

### DIFF
--- a/lib/sinon/mock.js
+++ b/lib/sinon/mock.js
@@ -54,6 +54,16 @@
             }
         }
 
+        function arrayEquals(arr1, arr2, compareLength) {
+            if (compareLength && (arr1.length !== arr2.length)) return false;
+            for (var i = 0, l = arr1.length; i < l; i++) {
+                if (!sinon.deepEqual(arr1[i], arr2[i])) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
         return {
             create: function create(object) {
                 if (!object) {
@@ -130,29 +140,41 @@
             },
 
             invokeMethod: function invokeMethod(method, thisValue, args) {
-                var expectations = this.expectations && this.expectations[method];
-                var length = expectations && expectations.length || 0, i;
+                var expectations = this.expectations && this.expectations[method] ? this.expectations[method] : [],
+                    expectationsWithMatchingArgs = [],
+                    currentArgs = args || [],
+                    i;
 
-                for (i = 0; i < length; i += 1) {
-                    if (!expectations[i].met() &&
-                        expectations[i].allowsCall(thisValue, args)) {
-                        return expectations[i].apply(thisValue, args);
+                for (i = 0; i < expectations.length; i += 1) {
+                    var expectedArgs = expectations[i].expectedArguments || [];
+                    if (arrayEquals(expectedArgs, currentArgs, expectations[i].expectsExactArgCount)) {
+                        expectationsWithMatchingArgs.push(expectations[i]);
+                    }
+                }
+
+                for (i = 0; i < expectationsWithMatchingArgs.length; i += 1) {
+                    if (!expectationsWithMatchingArgs[i].met() &&
+                        expectationsWithMatchingArgs[i].allowsCall(thisValue, args)) {
+                        return expectationsWithMatchingArgs[i].apply(thisValue, args);
                     }
                 }
 
                 var messages = [], available, exhausted = 0;
 
-                for (i = 0; i < length; i += 1) {
-                    if (expectations[i].allowsCall(thisValue, args)) {
-                        available = available || expectations[i];
+                for (i = 0; i < expectationsWithMatchingArgs.length; i += 1) {
+                    if (expectationsWithMatchingArgs[i].allowsCall(thisValue, args)) {
+                        available = available || expectationsWithMatchingArgs[i];
                     } else {
                         exhausted += 1;
                     }
-                    push.call(messages, "    " + expectations[i].toString());
                 }
 
-                if (exhausted === 0) {
+                if (available && exhausted === 0) {
                     return available.apply(thisValue, args);
+                }
+
+                for (i = 0; i < expectations.length; i += 1) {
+                    push.call(messages, "    " + expectations[i].toString());
                 }
 
                 messages.unshift("Unexpected call: " + sinon.spyCall.toString.call({

--- a/test/sinon/mock_test.js
+++ b/test/sinon/mock_test.js
@@ -304,6 +304,21 @@ buster.testCase("sinon.mock", {
                     obj.foobar();
                     mock.verify();
                 });
+            },
+
+            "nots throw when exceeding at least expectation and withargs": function () {
+                var obj = { foobar: function () {} };
+                var mock = sinon.mock(obj);
+
+                mock.expects("foobar").withArgs("arg1");
+                mock.expects("foobar").atLeast(1).withArgs("arg2");
+
+                
+                obj.foobar("arg1");
+                obj.foobar("arg2");
+                obj.foobar("arg2");
+
+                assert(mock.verify());
             }
         },
 


### PR DESCRIPTION
If a mock has a single ‘withArgs’ expectation that is expected to be called once, and another that is expected atLeast(1), the atLeast(1) expectations fails when called twice.

The "nots throw when exceeding at least expectation and withargs" test highlights the issue which is fixed with this commit.