### PR TITLE
Verify API in AMD context

### DIFF
--- a/lib/sinon.js
+++ b/lib/sinon.js
@@ -6,9 +6,9 @@
  *
  * Copyright (c) 2010-2013 Christian Johansen
  */
-"use strict";
+(function (global) {
+    "use strict";
 
-var sinon = (function () {
     var sinon;
     var isNode = typeof module !== "undefined" && module.exports && typeof require === "function";
     var isAMD = typeof define === "function" && typeof define.amd === "object" && define.amd;
@@ -42,5 +42,6 @@ var sinon = (function () {
         sinon = {};
     }
 
-    return sinon;
-}());
+    // export sinon into the global scope, if it doesn't exist there already
+    global.sinon = global.sinon || sinon;
+})(typeof self !== "undefined" ? self : this);

--- a/package.json
+++ b/package.json
@@ -27,13 +27,17 @@
     "util": ">=0.10.3 <1"
   },
   "devDependencies": {
-    "buster-core": ">=0.6.4",
+    "buster-amd": "~0.3.1",
     "buster-assertions": "~0.10",
+    "buster-core": ">=0.6.4",
     "buster-evented-logger": "~0.4",
-    "buster-test": "~0.5",
     "buster-format": "~0.5.6",
+    "buster-test": "~0.5",
     "http-server": "*",
-    "jscs": "~1.5.9"
+    "jscs": "~1.5.9",
+    "requirejs": "^2.1.14",
+    "phantomjs": "~1.9.7-15",
+    "buster": "~0.7.13"
   },
   "main": "./lib/sinon.js",
   "engines": {

--- a/script/add-node-modules-bin.sh
+++ b/script/add-node-modules-bin.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+export PATH=`pwd`/node_modules/.bin:$PATH

--- a/script/kill-subprocesses.sh
+++ b/script/kill-subprocesses.sh
@@ -1,0 +1,10 @@
+function finish {
+    if [ -n "${TRAVIS+1}" ]; then
+        echo "TRAVIS detected, skip killing child processes"
+    else
+        echo "Tidying up child processes"
+        kill $(jobs -pr)
+    fi
+}
+
+trap finish SIGINT SIGTERM EXIT

--- a/script/test-buster.sh
+++ b/script/test-buster.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -eu
+
+function finish {
+    if [ -n "${TRAVIS+1}" ]; then
+      echo "TRAVIS detected, skip killing child processes"
+    else
+      kill $(jobs -pr)
+    fi
+}
+
+trap finish SIGINT SIGTERM EXIT
+
+echo 'Building Sinon'
+./build
+
+echo 'Starting buster-server on port 1111'
+buster-server --capture-headless  & # this leaks a phantomjs process, need to report this and have buster fix it
+
+sleep 2 #give buster-server 2 seconds to start phantom, or things will not work
+
+echo 'Running unit tests in PhantomJS'
+buster-test --config test-buster/buster.js

--- a/script/test-buster.sh
+++ b/script/test-buster.sh
@@ -1,18 +1,7 @@
 #!/usr/bin/env bash
 set -eu
-
-function finish {
-    if [ -n "${TRAVIS+1}" ]; then
-      echo "TRAVIS detected, skip killing child processes"
-    else
-      kill $(jobs -pr)
-    fi
-}
-
-trap finish SIGINT SIGTERM EXIT
-
-echo 'Building Sinon'
-./build
+source ./script/add-node-modules-bin.sh
+source ./script/kill-subprocesses.sh
 
 echo 'Starting buster-server on port 1111'
 buster-server --capture-headless  & # this leaks a phantomjs process, need to report this and have buster fix it

--- a/test-buster/built/README.md
+++ b/test-buster/built/README.md
@@ -1,0 +1,1 @@
+The tests in this folder should verify the built version of SinonJS

--- a/test-buster/buster.js
+++ b/test-buster/buster.js
@@ -1,0 +1,26 @@
+var config = module.exports;
+
+// IMPORTANT: In this configuration we do not load the source files with the "sources" directive,
+// as we need the AMD loader to load them, so we can verify that works
+// They will be made available to RequireJS via the resources directive
+config["AMD compatibility - source version"] = {
+    environment: "browser",
+
+    rootPath: "../",
+
+    libs: [
+        "node_modules/requirejs/require.js"
+    ],
+
+    resources: [
+        "lib/**/*.js"
+    ],
+
+    tests: [
+        "test-buster/**/*-test.js"
+    ],
+
+    extensions: [
+        require("buster-amd")
+    ]
+};

--- a/test-buster/source/README.md
+++ b/test-buster/source/README.md
@@ -1,0 +1,1 @@
+The tests in this folder should verify the source version of SinonJS

--- a/test-buster/source/verify-api-amd-test.js
+++ b/test-buster/source/verify-api-amd-test.js
@@ -1,0 +1,81 @@
+// sinon.js doesn't overwrite the global and returns a different version than the one provided by BusterJS
+define(["../../lib/sinon"], function (targetSinon) {
+
+    var assert = buster.assert,
+        refute = buster.refute;
+
+    // This test case is not about testing individual modules, but only here
+    // to verify that the API is correctly assembled when loaded with an AMD loader in async
+    // mode (script tags), in this case using RequireJS
+    buster.testCase("Verify API for AMD compatibility - source version", {
+
+        sinon: {
+            "must not be same as BusterJS' bundled version": function () {
+                targetSinon.bogusProperty = "some bogus value";
+                assert.defined(targetSinon.bogusProperty);
+                refute.defined(sinon.bogusProperty);
+            },
+
+            // see http://sinonjs.org/docs/#spies
+            spies: {
+                "spy method": {
+                    "should be a Function": function () {
+                        assert.isFunction(targetSinon.spy);
+                    }
+                }
+            },
+
+            // see http://sinonjs.org/docs/#stubs
+            stubs: {
+                "stub method": {
+                    "should be a function": function () {
+                        assert.isFunction(targetSinon.stub);
+                    }
+                }
+            },
+
+            // see http://sinonjs.org/docs/#mocks
+            mocks: {
+                "mock method": {
+                    "should be a Function": function () {
+                        assert.isFunction(targetSinon.mock);
+                    }
+                }
+            },
+
+            // see http://sinonjs.org/docs/#clock
+            "fake timers": {
+                "useFakeTimers method": {
+                    "should be a Function": function () {
+                        assert.isFunction(targetSinon.useFakeTimers);
+                    }
+                }
+            },
+
+            // see http://sinonjs.org/docs/#server
+            "fake XHR and server": {
+                "useFakeXMLHttpRequest method": {
+                    "should be a Function": function () {
+                        assert.isFunction(targetSinon.useFakeXMLHttpRequest);
+                    }
+                }
+            },
+
+            assertions: {
+                "assertion property": {
+                    "should be an Object": function () {
+                        assert.isObject(targetSinon.assert);
+                    }
+                }
+            },
+
+            matchers: {
+                "match method": {
+                    "should be a function": function () {
+                        assert.isFunction(targetSinon.match);
+                    }
+                }
+            }
+        }
+    });
+});

--- a/test/ci-test.sh
+++ b/test/ci-test.sh
@@ -13,3 +13,5 @@ fi
 
 npm test
 test/phantom/run.sh
+
+./script/test-buster.sh

--- a/test/phantom/run.sh
+++ b/test/phantom/run.sh
@@ -1,15 +1,7 @@
 #!/usr/bin/env bash
 set -eu
 
-function finish {
-	if [ -n "${TRAVIS+1}" ]; then
-	  echo "TRAVIS detected, skip killing child processes"
-	else
-	  kill $(jobs -pr)
-	fi
-}
-
-trap finish SIGINT SIGTERM EXIT
+source ./script/kill-subprocesses.sh
 
 echo 'Starting webserver on port 8666'
 python -m SimpleHTTPServer 8666 &


### PR DESCRIPTION
This pull requests verifies that the API works in AMD contexts by loading SinonJS using RequireJS.

It currently breaks the built version, as `lib/sinon.js` no longer declares a global variable and only assigns to `global.sinon` if it is falsy. This is needed in order to separate the target Sinon from the BusterJS provided Sinon.
This also means that we can use unmodified BusterJS for the tests :clap: 

The build script needs fixing, input welcome! 

I just need a break and could with some feedback on this pull request before spending too much time down the wrong path.

**Update:** master is broken, the built version doesn't work there. Am investigating that first