### PR TITLE
check CORS support before using FakeXMLHttpRequest

### DIFF
--- a/lib/sinon/util/fake_server.js
+++ b/lib/sinon/util/fake_server.js
@@ -80,7 +80,11 @@ if (typeof sinon == "undefined") {
         sinon.fakeServer = {
             create: function () {
                 var server = create(this);
-                this.xhr = sinon.useFakeXMLHttpRequest();
+                if (!sinon.xhr.supportsCORS) {
+                    this.xhr = sinon.useFakeXDomainRequest();
+                } else {
+                    this.xhr = sinon.useFakeXMLHttpRequest();
+                }
                 server.requests = [];
 
                 this.xhr.onCreate = function (xhrObj) {


### PR DESCRIPTION
This resolves  #584 fakeServer not Working in IE9

sinon.useFakeXMLHttpRequest() was being called even when the browser didn't support CORS, this makes sure that sinon.useFakeXDomainRequest() is called instead if the browser doesn't support CORS