### PR TITLE
Don't setContent-type when sending FormData

### DIFF
--- a/lib/sinon/util/fake_xml_http_request.js
+++ b/lib/sinon/util/fake_xml_http_request.js
@@ -420,7 +420,7 @@
                     if (this.requestHeaders[contentType]) {
                         var value = this.requestHeaders[contentType].split(";");
                         this.requestHeaders[contentType] = value[0] + ";charset=utf-8";
-                    } else {
+                    } else if (!(data instanceof FormData)) {
                         this.requestHeaders["Content-Type"] = "text/plain;charset=utf-8";
                     }
 

--- a/test/sinon/util/fake_xml_http_request_test.js
+++ b/test/sinon/util/fake_xml_http_request_test.js
@@ -336,6 +336,15 @@
                 assert.equals(this.xhr.requestHeaders["content-type"], "application/json;charset=utf-8")
             },
 
+            "does not add 'Content-Type' header if data is FormData": function () {
+                this.xhr.open("POST", "/");
+                var formData = new FormData();
+                formData.append("username", "biz");
+                this.xhr.send("Data");
+
+                assert.equals(this.xhr.requestHeaders["content-type"], undefined)
+            },
+
             "sets request body to string data": function () {
                 this.xhr.open("POST", "/");
                 this.xhr.send("Data");


### PR DESCRIPTION
This prevents setting a default content-type header when a formdata payload is being set. The current behavior makes it impossible to test that we're sending FormData correctly.