### PR TITLE
Wrap IE specific files to properly set methods on window or global

### DIFF
--- a/lib/sinon/util/timers_ie.js
+++ b/lib/sinon/util/timers_ie.js
@@ -1,4 +1,4 @@
-(function(global){
+(function (global) {
     "use strict";
 
     /**

--- a/lib/sinon/util/timers_ie.js
+++ b/lib/sinon/util/timers_ie.js
@@ -1,4 +1,4 @@
-(function(sinon, global){
+(function(global){
     "use strict";
 
     /**
@@ -14,22 +14,12 @@
      *
      * Copyright (c) 2010-2013 Christian Johansen
      */
-    global.setTimeout = function setTimeout() {}
-    global.clearTimeout = function clearTimeout() {}
-    global.setImmediate = function setImmediate() {}
-    global.clearImmediate = function clearImmediate() {}
-    global.setInterval = function setInterval() {}
-    global.clearInterval = function clearInterval() {}
-    global.Date = function Date() {}
+    global.setTimeout = global.setTimeout;
+    global.clearTimeout = global.clearTimeout;
+    global.setImmediate = global.setImmediate;
+    global.clearImmediate = global.clearImmediate;
+    global.setInterval = global.setInterval;
+    global.clearInterval = global.clearInterval;
+    global.Date = global.Date;
 
-    // Reassign the original functions. Now their writable attribute
-    // should be true. Hackish, I know, but it works.
-    global.setTimeout = sinon.timers.setTimeout;
-    global.clearTimeout = sinon.timers.clearTimeout;
-    global.setImmediate = sinon.timers.setImmediate;
-    global.clearImmediate = sinon.timers.clearImmediate;
-    global.setInterval = sinon.timers.setInterval;
-    global.clearInterval = sinon.timers.clearInterval;
-    global.Date = sinon.timers.Date;
-
-})(typeof sinon == "object" && sinon || null, typeof window != "undefined" ? window : (typeof self != "undefined") ? self : global);
+})(typeof window != "undefined" ? window : (typeof self != "undefined") ? self : global);

--- a/lib/sinon/util/timers_ie.js
+++ b/lib/sinon/util/timers_ie.js
@@ -1,30 +1,35 @@
-/**
- * Helps IE run the fake timers. By defining global functions, IE allows
- * them to be overwritten at a later point. If these are not defined like
- * this, overwriting them will result in anything from an exception to browser
- * crash.
- *
- * If you don't require fake timers to work in IE, don't include this file.
- *
- * @author Christian Johansen (christian@cjohansen.no)
- * @license BSD
- *
- * Copyright (c) 2010-2013 Christian Johansen
- */
-function setTimeout() {}
-function clearTimeout() {}
-function setImmediate() {}
-function clearImmediate() {}
-function setInterval() {}
-function clearInterval() {}
-function Date() {}
+(function(sinon, global){
+    "use strict";
 
-// Reassign the original functions. Now their writable attribute
-// should be true. Hackish, I know, but it works.
-setTimeout = sinon.timers.setTimeout;
-clearTimeout = sinon.timers.clearTimeout;
-setImmediate = sinon.timers.setImmediate;
-clearImmediate = sinon.timers.clearImmediate;
-setInterval = sinon.timers.setInterval;
-clearInterval = sinon.timers.clearInterval;
-Date = sinon.timers.Date;
+    /**
+     * Helps IE run the fake timers. By defining global functions, IE allows
+     * them to be overwritten at a later point. If these are not defined like
+     * this, overwriting them will result in anything from an exception to browser
+     * crash.
+     *
+     * If you don't require fake timers to work in IE, don't include this file.
+     *
+     * @author Christian Johansen (christian@cjohansen.no)
+     * @license BSD
+     *
+     * Copyright (c) 2010-2013 Christian Johansen
+     */
+    global.setTimeout = function setTimeout() {}
+    global.clearTimeout = function clearTimeout() {}
+    global.setImmediate = function setImmediate() {}
+    global.clearImmediate = function clearImmediate() {}
+    global.setInterval = function setInterval() {}
+    global.clearInterval = function clearInterval() {}
+    global.Date = function Date() {}
+
+    // Reassign the original functions. Now their writable attribute
+    // should be true. Hackish, I know, but it works.
+    global.setTimeout = sinon.timers.setTimeout;
+    global.clearTimeout = sinon.timers.clearTimeout;
+    global.setImmediate = sinon.timers.setImmediate;
+    global.clearImmediate = sinon.timers.clearImmediate;
+    global.setInterval = sinon.timers.setInterval;
+    global.clearInterval = sinon.timers.clearInterval;
+    global.Date = sinon.timers.Date;
+
+}}(typeof sinon == "object" && sinon || null, typeof window != "undefined" ? window : (typeof self != "undefined") ? self : global));

--- a/lib/sinon/util/timers_ie.js
+++ b/lib/sinon/util/timers_ie.js
@@ -32,4 +32,4 @@
     global.clearInterval = sinon.timers.clearInterval;
     global.Date = sinon.timers.Date;
 
-}}(typeof sinon == "object" && sinon || null, typeof window != "undefined" ? window : (typeof self != "undefined") ? self : global));
+})(typeof sinon == "object" && sinon || null, typeof window != "undefined" ? window : (typeof self != "undefined") ? self : global);

--- a/lib/sinon/util/xdr_ie.js
+++ b/lib/sinon/util/xdr_ie.js
@@ -9,10 +9,10 @@
      *
      * If you don't require fake XDR to work in IE, don't include this file.
      */
-    global.XDomainRequest = function XDomainRequest() {}
+    global.XDomainRequest = function XDomainRequest() {};
 
     // Reassign the original function. Now its writable attribute
     // should be true. Hackish, I know, but it works.
     global.XDomainRequest = sinon.xdr.XDomainRequest || undefined;
 
-}}(typeof sinon == "object" && sinon || null, typeof window != "undefined" ? window : (typeof self != "undefined") ? self : global));
+})(typeof sinon == "object" && sinon || null, typeof window != "undefined" ? window : (typeof self != "undefined") ? self : global);

--- a/lib/sinon/util/xdr_ie.js
+++ b/lib/sinon/util/xdr_ie.js
@@ -1,4 +1,4 @@
-(function(global){
+(function (global) {
     "use strict";
 
     /**

--- a/lib/sinon/util/xdr_ie.js
+++ b/lib/sinon/util/xdr_ie.js
@@ -1,4 +1,4 @@
-(function(sinon, global){
+(function(global){
     "use strict";
 
     /**
@@ -9,10 +9,6 @@
      *
      * If you don't require fake XDR to work in IE, don't include this file.
      */
-    global.XDomainRequest = function XDomainRequest() {};
+    global.XDomainRequest = global.XDomainRequest;
 
-    // Reassign the original function. Now its writable attribute
-    // should be true. Hackish, I know, but it works.
-    global.XDomainRequest = sinon.xdr.XDomainRequest || undefined;
-
-})(typeof sinon == "object" && sinon || null, typeof window != "undefined" ? window : (typeof self != "undefined") ? self : global);
+})(typeof window != "undefined" ? window : (typeof self != "undefined") ? self : global);

--- a/lib/sinon/util/xdr_ie.js
+++ b/lib/sinon/util/xdr_ie.js
@@ -1,13 +1,18 @@
-/**
- * Helps IE run the fake XDomainRequest. By defining global functions, IE allows
- * them to be overwritten at a later point. If these are not defined like
- * this, overwriting them will result in anything from an exception to browser
- * crash.
- *
- * If you don't require fake XDR to work in IE, don't include this file.
- */
-function XDomainRequest() {}
+(function(sinon, global){
+    "use strict";
 
-// Reassign the original function. Now its writable attribute
-// should be true. Hackish, I know, but it works.
-XDomainRequest = sinon.xdr.XDomainRequest || undefined;
+    /**
+     * Helps IE run the fake XDomainRequest. By defining global functions, IE allows
+     * them to be overwritten at a later point. If these are not defined like
+     * this, overwriting them will result in anything from an exception to browser
+     * crash.
+     *
+     * If you don't require fake XDR to work in IE, don't include this file.
+     */
+    global.XDomainRequest = function XDomainRequest() {}
+
+    // Reassign the original function. Now its writable attribute
+    // should be true. Hackish, I know, but it works.
+    global.XDomainRequest = sinon.xdr.XDomainRequest || undefined;
+
+}}(typeof sinon == "object" && sinon || null, typeof window != "undefined" ? window : (typeof self != "undefined") ? self : global));

--- a/lib/sinon/util/xhr_ie.js
+++ b/lib/sinon/util/xhr_ie.js
@@ -1,4 +1,4 @@
-(function(global){
+(function (global) {
     "use strict";
 
     /**

--- a/lib/sinon/util/xhr_ie.js
+++ b/lib/sinon/util/xhr_ie.js
@@ -20,4 +20,4 @@
     // should be true. Hackish, I know, but it works.
     global.XMLHttpRequest = sinon.xhr.XMLHttpRequest || undefined;
 
-}}(typeof sinon == "object" && sinon || null, typeof window != "undefined" ? window : (typeof self != "undefined") ? self : global));
+})(typeof sinon == "object" && sinon || null, typeof window != "undefined" ? window : (typeof self != "undefined") ? self : global);

--- a/lib/sinon/util/xhr_ie.js
+++ b/lib/sinon/util/xhr_ie.js
@@ -1,18 +1,23 @@
-/**
- * Helps IE run the fake XMLHttpRequest. By defining global functions, IE allows
- * them to be overwritten at a later point. If these are not defined like
- * this, overwriting them will result in anything from an exception to browser
- * crash.
- *
- * If you don't require fake XHR to work in IE, don't include this file.
- *
- * @author Christian Johansen (christian@cjohansen.no)
- * @license BSD
- *
- * Copyright (c) 2010-2013 Christian Johansen
- */
-function XMLHttpRequest() {}
+(function(sinon, global){
+    "use strict";
 
-// Reassign the original function. Now its writable attribute
-// should be true. Hackish, I know, but it works.
-XMLHttpRequest = sinon.xhr.XMLHttpRequest || undefined;
+    /**
+     * Helps IE run the fake XMLHttpRequest. By defining global functions, IE allows
+     * them to be overwritten at a later point. If these are not defined like
+     * this, overwriting them will result in anything from an exception to browser
+     * crash.
+     *
+     * If you don't require fake XHR to work in IE, don't include this file.
+     *
+     * @author Christian Johansen (christian@cjohansen.no)
+     * @license BSD
+     *
+     * Copyright (c) 2010-2013 Christian Johansen
+     */
+    global.XMLHttpRequest = function XMLHttpRequest() {}
+
+    // Reassign the original function. Now its writable attribute
+    // should be true. Hackish, I know, but it works.
+    global.XMLHttpRequest = sinon.xhr.XMLHttpRequest || undefined;
+
+}}(typeof sinon == "object" && sinon || null, typeof window != "undefined" ? window : (typeof self != "undefined") ? self : global));

--- a/lib/sinon/util/xhr_ie.js
+++ b/lib/sinon/util/xhr_ie.js
@@ -1,4 +1,4 @@
-(function(sinon, global){
+(function(global){
     "use strict";
 
     /**
@@ -14,10 +14,6 @@
      *
      * Copyright (c) 2010-2013 Christian Johansen
      */
-    global.XMLHttpRequest = function XMLHttpRequest() {}
+    global.XMLHttpRequest = global.XMLHttpRequest;
 
-    // Reassign the original function. Now its writable attribute
-    // should be true. Hackish, I know, but it works.
-    global.XMLHttpRequest = sinon.xhr.XMLHttpRequest || undefined;
-
-})(typeof sinon == "object" && sinon || null, typeof window != "undefined" ? window : (typeof self != "undefined") ? self : global);
+})(typeof window != "undefined" ? window : (typeof self != "undefined") ? self : global);

--- a/test/sinon.html
+++ b/test/sinon.html
@@ -12,6 +12,9 @@
         Sinon.JS bundled inside Buster.JS (which it is in the official
         distribution).
       -->
+    <script src="../lib/sinon/util/xhr_ie.js"></script>
+    <script src="../lib/sinon/util/xdr_ie.js"></script>
+    <script src="../lib/sinon/util/timers_ie.js"></script>
     <script src="../node_modules/buster-core/lib/buster-core.js"></script>
     <script src="../node_modules/buster-core/lib/buster-event-emitter.js"></script>
     <script src="../node_modules/buster-format/lib/buster-format.js"></script>
@@ -50,9 +53,6 @@
     <script src="../lib/sinon/util/fake_xml_http_request.js"></script>
     <script src="../lib/sinon/util/fake_timers.js"></script>
     <script src="../lib/sinon/util/fake_xdomain_request.js"></script>
-    <script src="../lib/sinon/util/xhr_ie.js"></script>
-    <script src="../lib/sinon/util/xdr_ie.js"></script>
-    <script src="../lib/sinon/util/timers_ie.js"></script>
     <script src="../lib/sinon/util/fake_server.js"></script>
     <script src="../lib/sinon/util/fake_server_with_clock.js"></script>
     <script src="../lib/sinon/collection.js"></script>

--- a/test/sinon/issues/issues.js
+++ b/test/sinon/issues/issues.js
@@ -19,7 +19,7 @@ buster.testCase("issues", {
     tearDown: function () {
         this.sandbox.restore();
 
-        if (this.clock){
+        if (this.clock) {
             this.clock.restore();
         }
     },


### PR DESCRIPTION
Unwrapped code can cause issues with `this` if the code is appended to other code that has 'use strict' defined outside of a function scope.

To prevent any issues in reference to `this`, wrap the IE code in a self-executing function and make any changes to a reference to `window` or `global`.