### PR TITLE
Fix #633. Use a try/catch when deleting a property in IE8.

### DIFF
--- a/lib/sinon/sandbox.js
+++ b/lib/sinon/sandbox.js
@@ -100,7 +100,12 @@
             restoreContext: function () {
                 if (this.injectedKeys) {
                     for (var i = 0, j = this.injectedKeys.length; i < j; i++) {
-                        delete this.injectInto[this.injectedKeys[i]];
+                        // Use a try/catch to delete a property in IE8
+                        try {
+                            delete this.injectInto[this.injectedKeys[i]];
+                        } catch (e) {
+                            this.injectInto[this.injectedKeys[i]] = undefined
+                        }
                     }
                     this.injectedKeys = [];
                 }

--- a/lib/sinon/sandbox.js
+++ b/lib/sinon/sandbox.js
@@ -104,7 +104,7 @@
                         try {
                             delete this.injectInto[this.injectedKeys[i]];
                         } catch (e) {
-                            this.injectInto[this.injectedKeys[i]] = undefined
+                            this.injectInto[this.injectedKeys[i]] = undefined;
                         }
                     }
                     this.injectedKeys = [];

--- a/test/sinon/issues/issues.js
+++ b/test/sinon/issues/issues.js
@@ -19,7 +19,7 @@ buster.testCase("issues", {
     tearDown: function () {
         this.sandbox.restore();
 
-        if (this.clock){
+        if (this.clock) {
             this.clock.restore();
         }
     },


### PR DESCRIPTION
Use a try/catch when deleting a property in IE8.