### PR TITLE
Add safety check for document.createElement and setInterval

### DIFF
--- a/lib/sinon/util/core.js
+++ b/lib/sinon/util/core.js
@@ -12,7 +12,7 @@
 "use strict";
 
 (function (sinon) {
-    var div = typeof document != "undefined" && document.createElement("div");
+    var div = typeof document != "undefined" && document.createElement && document.createElement("div");
     var hasOwn = Object.prototype.hasOwnProperty;
 
     function isDOMNode(obj) {

--- a/lib/sinon/util/fake_timers.js
+++ b/lib/sinon/util/fake_timers.js
@@ -52,8 +52,8 @@ if (typeof sinon == "undefined") {
             clearTimeout: clearTimeout,
             setImmediate: (typeof setImmediate !== "undefined" ? setImmediate : undefined),
             clearImmediate: (typeof clearImmediate !== "undefined" ? clearImmediate : undefined),
-            setInterval: setInterval,
-            clearInterval: clearInterval,
+            setInterval: (typeof setInterval !== "undefined" ? setInterval : undefined),
+            clearInterval: (typeof clearInterval !== "undefined" ? clearInterval : undefined),
             Date: Date
         };
     }


### PR DESCRIPTION
Mostly specific to https://github.com/walmartlabs/fruit-loops but adds one more layer of safety should other environments have a global named document that is not strictly a DOM document.

This showed test failures locally but these appeared to be unrelated to this change being in the clock logic and did not appear to fail consistently with or without this patch.