### PR TITLE
Fix #643. Returns supersedes previous throws

### DIFF
--- a/lib/sinon/behavior.js
+++ b/lib/sinon/behavior.js
@@ -275,6 +275,7 @@
             returns: function returns(value) {
                 this.returnValue = value;
                 this.returnValueDefined = true;
+                this.exception = undefined;
 
                 return this;
             },

--- a/test/sinon/stub_test.js
+++ b/test/sinon/stub_test.js
@@ -70,6 +70,15 @@ buster.testCase("sinon.stub", {
             var stub = sinon.stub.create();
 
             refute.defined(stub());
+        },
+
+        "supersedes previous throws": function () {
+            var stub = sinon.stub.create();
+            stub.throws().returns();
+
+            refute.exception(function () {
+                stub();
+            });
         }
     },
 


### PR DESCRIPTION
With these changes, `stub.throws().returns()` will return instead of throw.  See #643 for details.