### PR TITLE
Aligned sandbox.useFakeXMLHttpRequest API to documentation - resolves #393

### DIFF
--- a/lib/sinon/sandbox.js
+++ b/lib/sinon/sandbox.js
@@ -76,7 +76,7 @@
             },
 
             useFakeXMLHttpRequest: function useFakeXMLHttpRequest() {
-              return this.xhr = this.useFakeServer().xhr;
+                return this.xhr = this.useFakeServer().xhr;
             },
 
             inject: function (obj) {

--- a/lib/sinon/sandbox.js
+++ b/lib/sinon/sandbox.js
@@ -75,6 +75,10 @@
                 return this.add(this.server);
             },
 
+            useFakeXMLHttpRequest: function useFakeXMLHttpRequest() {
+              return this.xhr = this.useFakeServer().xhr;
+            },
+
             inject: function (obj) {
                 sinon.collection.inject.call(this, obj);
 
@@ -137,8 +141,6 @@
 
             match: sinon.match
         });
-
-        sinon.sandbox.useFakeXMLHttpRequest = sinon.sandbox.useFakeServer;
 
         return sinon.sandbox;
     }

--- a/test/sinon/sandbox_test.js
+++ b/test/sinon/sandbox_test.js
@@ -108,10 +108,10 @@ if (typeof require == "function" && typeof module == "object") {
                 },
 
                 "returns xhr": function () {
-                  var xhr = this.sandbox.useFakeXMLHttpRequest();
+                    var xhr = this.sandbox.useFakeXMLHttpRequest();
 
-                  assert.isFunction(xhr);
-                  assert.isFunction(xhr.restore);
+                    assert.isFunction(xhr);
+                    assert.isFunction(xhr.restore);
                 },
 
                 "exposes xhr property": function () {

--- a/test/sinon/sandbox_test.js
+++ b/test/sinon/sandbox_test.js
@@ -107,6 +107,19 @@ if (typeof require == "function" && typeof module == "object") {
                     this.sandbox.restore();
                 },
 
+                "returns xhr": function () {
+                  var xhr = this.sandbox.useFakeXMLHttpRequest();
+
+                  assert.isFunction(xhr);
+                  assert.isFunction(xhr.restore);
+                },
+
+                "exposes xhr property": function () {
+                    var xhr = this.sandbox.useFakeXMLHttpRequest();
+
+                    assert.same(this.sandbox.xhr, xhr);
+                },
+
                 "calls sinon.useFakeXMLHttpRequest": sinon.test(function () {
                     this.stub(sinon, "useFakeXMLHttpRequest").returns({ restore: function () {} });
                     this.sandbox.useFakeXMLHttpRequest();


### PR DESCRIPTION
This makes the documentation correct and keeps the usage consistent with `useFakeServer` and `useFakeTimers`.