### PR TITLE
Use FakeXDomainRequest when XHR does not support CORS. Fixes #584

### DIFF
--- a/lib/sinon/util/fake_server.js
+++ b/lib/sinon/util/fake_server.js
@@ -1,4 +1,5 @@
 /**
+ * @depend fake_xdomain_request.js
  * @depend fake_xml_http_request.js
  * @depend ../format.js
  * @depend ../log_error.js
@@ -80,7 +81,11 @@ if (typeof sinon == "undefined") {
         sinon.fakeServer = {
             create: function () {
                 var server = create(this);
-                this.xhr = sinon.useFakeXMLHttpRequest();
+                if (!sinon.xhr.supportsCORS) {
+                    this.xhr = sinon.useFakeXDomainRequest();
+                } else {
+                    this.xhr = sinon.useFakeXMLHttpRequest();
+                }
                 server.requests = [];
 
                 this.xhr.onCreate = function (xhrObj) {
@@ -216,6 +221,7 @@ if (typeof sinon == "undefined") {
 
     function loadDependencies(require, exports, module) {
         var sinon = require("./core");
+        require("./fake_xdomain_request");
         require("./fake_xml_http_request");
         makeApi(sinon);
         module.exports = sinon;


### PR DESCRIPTION
Related to #590 - Tests were breaking because fake_server was not correctly depending on `./fake_xdomain_request.js`. 

Note that I branched off of `v1.12.2` because tests are (as of this moment) broken on master. 

Cheers,
Eric