### PR TITLE
Remove request to add Github labels from CONTRIBUING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,8 +22,6 @@ As a minimum, please report the following:
 * What actually happens
 * Describe **with code** how to reproduce the faulty behaviour
 
-Also, if you could apply any GitHub labels that matches your issue (ex: AMD, XHR) that would be great!
-
 ### Bug report template
 
 Here's a template for a bug report


### PR DESCRIPTION
Only contributors to the Sinon project can modify an issue's labels.