### PR TITLE
Fix fakeXHR requests in Node.

### DIFF
--- a/lib/sinon/util/fake_xml_http_request.js
+++ b/lib/sinon/util/fake_xml_http_request.js
@@ -611,4 +611,4 @@
         makeApi(sinon);
     }
 
-})(typeof self !== "undefined" ? self : this);
+})(global ? global : this);


### PR DESCRIPTION
Sinon was unable to detect XHR support when loaded in certain
Node environments. This was a regression introduced in #515
to resolve #508 and #511.

Resolves #657