### PR TITLE
Add a test for issue #283 (commented out)

### DIFF
--- a/test/sinon/issues/issues.js
+++ b/test/sinon/issues/issues.js
@@ -20,6 +20,39 @@ buster.testCase("issues", {
         this.sandbox.restore();
     },
 
+    "// #283": function () {
+        function testSinonFakeTimersWith(interval, ticks) {
+            var clock = sinon.useFakeTimers();
+
+            var spy = sinon.spy();
+            var id = setInterval(spy, interval);
+            assert(!spy.calledOnce);
+            clock.tick(ticks);
+            assert(spy.calledOnce);
+
+            clearInterval(id);
+            clock.restore();
+        }
+
+        // FAILS
+        testSinonFakeTimersWith(10, 101);
+
+        // PASS
+        testSinonFakeTimersWith(99, 101);
+
+        // FAILS
+        testSinonFakeTimersWith(100, 200);
+
+        // PASS
+        testSinonFakeTimersWith(199, 200);
+
+        // FAILS
+        testSinonFakeTimersWith(500, 1001);
+
+        // PASS
+        testSinonFakeTimersWith(1000, 1001);
+    },
+
     "// #397": function () {
         var clock = sinon.useFakeTimers();
 


### PR DESCRIPTION
I verified the #283 issue  by running the excellent example, and the bug certainly does exist. However, there's a another bug around `.useFakeTimers` and `.restore()` that still plague us, so this is commented out to avoid the cascade of false positives.

This pull request adds a test to verify that #283 has been fixed (for when it does get fixed). 

Related: #624 