### PR TITLE
Add test for issue #397

### DIFF
--- a/test/sinon/issues/issues.js
+++ b/test/sinon/issues/issues.js
@@ -20,6 +20,26 @@ buster.testCase("issues", {
         this.sandbox.restore();
     },
 
+    "// #397": function(){
+        var clock = sinon.useFakeTimers();
+
+        var cb2 = sinon.spy();
+        var cb1 = sinon.spy(function() {
+            setTimeout(cb2, 0);
+        });
+
+        setTimeout(cb1, 0);
+
+        clock.tick(10);
+        assert(cb1.called);
+        assert(!cb2.called);
+
+        clock.tick(10);
+        assert(cb2.called);
+
+        clock.restore();
+    },
+
     "#458": {
         "on node": {
             requiresSupportFor: {


### PR DESCRIPTION
This test verifies issue #397.

It's commented out, because of previously mentioned issues with using `useFakeTimers` and `restore` more than once in the whole test run.