### PR TITLE
(AMD) use explicit define in built version

### DIFF
--- a/build
+++ b/build
@@ -48,7 +48,7 @@ formatio not found, skipping. To build with formatio support:
   File.open(file, "w") do |f|
     f.puts("(function (root, factory) {")
     f.puts("  if (typeof define === 'function' && define.amd) {")
-    f.puts("    define([], function () {")
+    f.puts("    define('sinon', [], function () {")
     f.puts("      return (root.sinon = factory());")
     f.puts("    });")
     f.puts("  } else if (typeof exports === 'object') {")


### PR DESCRIPTION
This should fix issues in test runners (Jasmine 2 with weird grunt
require plugins, karma, etc.) where users get the much dreaded
[mismatched anonymous define modules](http://requirejs.org/docs/errors.html#mismatch)
error when loading Sinon.JS via RequireJS.

I am not yet sure how to test this, feedback welcome.
One idea would be to write a few tests using RequireJS, that can be run via specific npm statements. 

This idea came from https://github.com/cjohansen/Sinon.JS/issues/591#issuecomment-67765972

See also: https://github.com/cjohansen/Sinon.JS/issues/639