### PR TITLE
Fixed assert when spyCall failed

### DIFF
--- a/lib/sinon/assert.js
+++ b/lib/sinon/assert.js
@@ -71,7 +71,7 @@
                 }
 
                 if (failed) {
-                    failAssertion(this, fake.printf.apply(fake, [message].concat(args)));
+                    failAssertion(this, (fake.printf || fake.proxy.printf).apply(fake, [message].concat(args)));
                 } else {
                     assert.pass(name);
                 }

--- a/test/sinon/assert_test.js
+++ b/test/sinon/assert_test.js
@@ -642,6 +642,19 @@ buster.testCase("sinon.assert", {
             sinon.assert.calledWith(spy.lastCall, object);
             assert(sinon.assert.pass.calledOnce);
             assert(sinon.assert.pass.calledWith("calledWith"));
+        },
+
+        "fails when spyCall failed": function () {
+            var spy = sinon.spy();
+            var object = {};
+            spy();
+            spy(object);
+
+            assert.exception(function () {
+                sinon.assert.calledWith(spy.lastCall, 1);
+            });
+
+            assert(sinon.assert.fail.called);
         }
     },
 


### PR DESCRIPTION
Assertions on spycalls worked "well" when it didn't fail, but broken for assertions that fail, this fixes it.