### PR TITLE
Argument Aliasing

### DIFF
--- a/lib/sinon/call.js
+++ b/lib/sinon/call.js
@@ -180,6 +180,7 @@
             proxyCall.returnValue = returnValue;
             proxyCall.exception = exception;
             proxyCall.callId = id;
+            sinon.setArgsOnAliasedProperties(spy.argNames, args, proxyCall);
 
             return proxyCall;
         }

--- a/lib/sinon/spy.js
+++ b/lib/sinon/spy.js
@@ -62,6 +62,28 @@
             this.lastCall = this.getCall(this.callCount - 1);
         }
 
+        function setArgsOnAliasedProperties(argNames, args, target) {
+            if (argNames) {
+                for (var i = 0, l = argNames.length; i < l; ++i) {
+                    target[prefixArgName(argNames[i])] = args[i];
+                }
+            }
+        }
+
+        function pushArgsOnAliasedArrays(argNames, args, target) {
+            if (argNames) {
+                for (var i = 0, l = argNames.length; i < l; ++i) {
+                    var argName = prefixArgName(argNames[i]);
+                    var aliasArray = target[argName] || (target[argName] = []);
+                    push.call(aliasArray, args[i]);
+                }
+            }
+        }
+
+        function prefixArgName(argName) {
+            return "_" + argName;
+        }
+
         var vars = "a,b,c,d,e,f,g,h,i,j,k,l";
         function createProxy(func, proxyLength) {
             // Retain the function length:
@@ -104,6 +126,7 @@
                 this.thisValues = [];
                 this.exceptions = [];
                 this.callIds = [];
+                this.argNames = null;
                 if (this.fakes) {
                     for (var i = 0; i < this.fakes.length; i++) {
                         this.fakes[i].reset();
@@ -150,6 +173,8 @@
                 push.call(this.thisValues, thisValue);
                 push.call(this.args, args);
                 push.call(this.callIds, callId++);
+
+                pushArgsOnAliasedArrays(this.argNames, args, this);
 
                 // Make call properties available from within the spied function:
                 createCallProperties.call(this);
@@ -249,6 +274,7 @@
                 var fake = this.instantiateFake();
                 fake.matchingAguments = args;
                 fake.parent = this;
+                fake.argNames = this.argNames;
                 push.call(this.fakes, fake);
 
                 fake.withArgs = function () {
@@ -263,6 +289,7 @@
                         push.call(fake.returnValues, this.returnValues[i]);
                         push.call(fake.exceptions, this.exceptions[i]);
                         push.call(fake.callIds, this.callIds[i]);
+                        sinon.pushArgsOnAliasedArrays(original.argNames, this.args[i], fake);
                     }
                 }
                 createCallProperties.call(fake);
@@ -417,6 +444,8 @@
 
         spy.spyCall = sinon.spyCall;
         sinon.spy = spy;
+        sinon.setArgsOnAliasedProperties = setArgsOnAliasedProperties;
+        sinon.pushArgsOnAliasedArrays = pushArgsOnAliasedArrays;
 
         return spy;
     }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "buster-test": "~0.5",
     "buster-format": "~0.5.6",
     "http-server": "*",
-    "jscs": "~1.5.9"
+    "jscs": "~1.6.0"
   },
   "main": "./lib/sinon.js",
   "engines": {

--- a/test/sinon/spy_test.js
+++ b/test/sinon/spy_test.js
@@ -901,6 +901,72 @@ if (typeof require === "function" && typeof module === "object") {
             }
         },
 
+        ".argNames": {
+            //jscs:disable disallowDanglingUnderscores
+            setUp: function () {
+                this.spy = sinon.spy.create();
+                this.spy.argNames = ["foo", "bar"];
+            },
+
+            "creates aliased argument arrays on spy": function () {
+                this.spy("baz", 1);
+                this.spy(false, {a:"b"});
+
+                assert.equals(this.spy._foo, ["baz", false]);
+                assert.equals(this.spy._bar, [1, {a:"b"}]);
+            },
+
+            "creates aliased argument properties on spyCalls": function () {
+                this.spy("baz", 1);
+                this.spy(false, {a:"b"});
+
+                assert.equals(this.spy.firstCall._foo, "baz");
+                assert.equals(this.spy.firstCall._bar, 1);
+                assert.equals(this.spy.secondCall._foo, false);
+                assert.equals(this.spy.secondCall._bar, {a:"b"});
+            },
+
+            "creates aliased argument arrays on withArgs fakes": function () {
+                this.spy("baz", "quz");
+                this.spy("fred", "waldo");
+                this.spy("baz", 1);
+                this.spy("fred", 2);
+                this.spy("baz", true);
+                this.spy("fred", {a:"b"});
+
+                var bazFake = this.spy.withArgs("baz");
+                var fredFake = this.spy.withArgs("fred");
+
+                assert.equals(bazFake._foo, ["baz", "baz", "baz"]);
+                assert.equals(bazFake._bar, ["quz", 1, true]);
+                assert.equals(fredFake._foo, ["fred", "fred", "fred"]);
+                assert.equals(fredFake._bar, ["waldo", 2, {a:"b"}]);
+            },
+
+            "creates aliased argument properties on withArgs spyCalls": function () {
+                this.spy("baz", "quz");
+                this.spy("fred", "waldo");
+                this.spy("baz", 1);
+                this.spy("fred", 2);
+                this.spy("baz", true);
+                this.spy("fred", {a:"b"});
+
+                var bazFake = this.spy.withArgs("baz");
+                var fredFake = this.spy.withArgs("fred");
+
+                assert.equals(bazFake.firstCall._foo, "baz");
+                assert.equals(bazFake.firstCall._bar, "quz");
+                assert.equals(bazFake.secondCall._bar, 1);
+                assert.equals(bazFake.thirdCall._bar, true);
+
+                assert.equals(fredFake.firstCall._foo, "fred");
+                assert.equals(fredFake.firstCall._bar, "waldo");
+                assert.equals(fredFake.secondCall._bar, 2);
+                assert.equals(fredFake.thirdCall._bar, {a:"b"});
+            }
+            //jscs:enable disallowDanglingUnderscores
+        },
+
         ".calledWithExactly": {
             setUp: function () {
                 this.spy = sinon.spy.create();


### PR DESCRIPTION
Aliases arguments so you can access them via meaningful property names instead of by array indexes.

Configure argument aliases, probably best used in `setUp` or `beforeEach` (setup is bit verbose for a single test).
```javascript
var spy = sinon.spy();
spy.argNames = ["path", "callBack"];  //The first argument is called "path", the second "callBack"
```

Call the spy as you normally wood:
```javascript
spy("a/b", fn1);
spy("b/c", fn2);
```

The `spy` object will now have custom-named properties, which are arrays populated with the named argument from each call. `spyCall` objects also get custom-named properties, they aren't (necessarily) arrays, but rather the actual named argument passed to that particular call.
```javascript
assert.equals(spy._path, ["a/b", "b/c"]);  
assert.same(spy.firstCall._callBack, fn1);
spy.withArgs("b/c").firsCall._callBack(); //calls fn2
```

The "`_`" prefix is added to avoid collisions with existing spy properties.

There are at few real benefits to using this approach:

1. Readability - `firstCall._path` conveys a bit more meaning than `firstCall.args[0]` (though perhaps it would be a bit clearer if I added the properties to the array instead - i.e. `firstCall.args._path`).
2. Finding usages of a particular arg in your tests is easier. Grepping for `._path` on your tests will likely return far fewer results than `.args[0]`.
2. Refactoring method signatures - If an argument changes position as your api evolves, simply fix the alias assignment in `setUp`, no need to refactor every test.