### PR TITLE
Feature: getters & setters

### DIFF
--- a/lib/sinon/spy.js
+++ b/lib/sinon/spy.js
@@ -16,12 +16,20 @@
 "use strict";
 
 (function (sinon) {
+    function getPropertyDescriptor(object, property) {
+        var proto = object, descriptor;
+        while (proto && !(descriptor = Object.getOwnPropertyDescriptor(proto, property))) {
+            proto = Object.getPrototypeOf(proto);
+        }
+        return descriptor;
+    }
+
     function makeApi(sinon) {
         var push = Array.prototype.push;
         var slice = Array.prototype.slice;
         var callId = 0;
 
-        function spy(object, property) {
+        function spy(object, property, types) {
             if (!property && typeof object == "function") {
                 return spy.create(object);
             }
@@ -30,8 +38,16 @@
                 return spy.create(function () { });
             }
 
-            var method = object[property];
-            return sinon.wrapMethod(object, property, spy.create(method));
+            if (types) {
+                var methodDesc = getPropertyDescriptor(object, property);
+                for (var i = 0; i < types.length; i++) {
+                    methodDesc[types[i]] = spy.create(methodDesc[types[i]]);
+                }
+                return sinon.wrapMethod(object, property, methodDesc);
+            } else {
+                var method = object[property];
+                return sinon.wrapMethod(object, property, spy.create(method));
+            }
         }
 
         function matchingFake(fakes, args, strict) {

--- a/lib/sinon/stub.js
+++ b/lib/sinon/stub.js
@@ -17,14 +17,24 @@
 (function (sinon) {
     function makeApi(sinon) {
         function stub(object, property, func) {
-            if (!!func && typeof func != "function") {
-                throw new TypeError("Custom stub should be function");
+            if (!!func && typeof func != "function" && typeof func != "object") {
+                throw new TypeError("Custom stub should be a function or a property descriptor");
             }
 
             var wrapper;
 
             if (func) {
-                wrapper = sinon.spy && sinon.spy.create ? sinon.spy.create(func) : func;
+                if (typeof func == "function") {
+                    wrapper = sinon.spy && sinon.spy.create ? sinon.spy.create(func) : func;
+                } else {
+                    wrapper = func;
+                    if (sinon.spy && sinon.spy.create) {
+                        var types = Object.keys(wrapper);
+                        for (var i = 0; i < types.length; i++) {
+                            wrapper[types[i]] = sinon.spy.create(wrapper[types[i]]);
+                        }
+                    }
+                }
             } else {
                 var stubLength = 0;
                 if (typeof object == "object" && typeof object[property] == "function") {

--- a/lib/sinon/util/core.js
+++ b/lib/sinon/util/core.js
@@ -15,6 +15,14 @@
     var div = typeof document != "undefined" && document.createElement("div");
     var hasOwn = Object.prototype.hasOwnProperty;
 
+    function getPropertyDescriptor(object, property) {
+        var proto = object, descriptor;
+        while (proto && !(descriptor = Object.getOwnPropertyDescriptor(proto, property))) {
+            proto = Object.getPrototypeOf(proto);
+        }
+        return descriptor;
+    }
+
     function isDOMNode(obj) {
         var success = false;
 
@@ -64,34 +72,55 @@
                 throw new TypeError("Should wrap property of object");
             }
 
-            if (typeof method != "function") {
-                throw new TypeError("Method wrapper should be function");
+            if (typeof method != "function" && typeof method != "object") {
+                throw new TypeError("Method wrapper should be a function or a property descriptor");
             }
+            var methodDesc = (typeof method == "function") ? {value: method} : method,
+                wrappedMethodDesc = getPropertyDescriptor(object, property),
+                error, i, wrappedMethod;
 
-            var wrappedMethod = object[property],
-                error;
-
-            if (!isFunction(wrappedMethod)) {
+            if (!wrappedMethodDesc) {
                 error = new TypeError("Attempted to wrap " + (typeof wrappedMethod) + " property " +
                                     property + " as function");
-            } else if (wrappedMethod.restore && wrappedMethod.restore.sinon) {
+            } else if (wrappedMethodDesc.restore && wrappedMethodDesc.restore.sinon) {
                 error = new TypeError("Attempted to wrap " + property + " which is already wrapped");
-            } else if (wrappedMethod.calledBefore) {
-                var verb = !!wrappedMethod.returns ? "stubbed" : "spied on";
-                error = new TypeError("Attempted to wrap " + property + " which is already " + verb);
             }
-
             if (error) {
-                if (wrappedMethod && wrappedMethod.stackTrace) {
-                    error.stack += "\n--------------\n" + wrappedMethod.stackTrace;
+                if (wrappedMethodDesc && wrappedMethodDesc.stackTrace) {
+                    error.stack += "\n--------------\n" + wrappedMethodDesc.stackTrace;
                 }
                 throw error;
+            }
+
+            var types = Object.keys(methodDesc);
+            for (i = 0; i < types.length; i++) {
+                wrappedMethod = wrappedMethodDesc[types[i]];
+                if (!isFunction(wrappedMethod)) {
+                    error = new TypeError("Attempted to wrap " + (typeof wrappedMethod) + " property " +
+                                        property + " as function");
+                } else if (wrappedMethod.restore && wrappedMethod.restore.sinon) {
+                    error = new TypeError("Attempted to wrap " + property + " which is already wrapped");
+                } else if (wrappedMethod.calledBefore) {
+                    var verb = !!wrappedMethod.returns ? "stubbed" : "spied on";
+                    error = new TypeError("Attempted to wrap " + property + " which is already " + verb);
+                }
+                if (error) {
+                    if (wrappedMethod && wrappedMethod.stackTrace) {
+                        error.stack += "\n--------------\n" + wrappedMethod.stackTrace;
+                    }
+                    throw error;
+                }
             }
 
             // IE 8 does not support hasOwnProperty on the window object and Firefox has a problem
             // when using hasOwn.call on objects from other frames.
             var owned = object.hasOwnProperty ? object.hasOwnProperty(property) : hasOwn.call(object, property);
-            object[property] = method;
+            mirrorProperties(methodDesc, wrappedMethodDesc);
+            for (i = 0; i < types.length; i++) {
+                mirrorProperties(methodDesc[types[i]], wrappedMethodDesc[types[i]]);
+            }
+            Object.defineProperty(object, property, methodDesc);
+
             method.displayName = property;
             // Set up a stack trace which can be used later to find what line of
             // code the original method was created on.
@@ -103,14 +132,12 @@
                 // via direct assignment.
                 if (!owned) {
                     delete object[property];
-                }
-                if (object[property] === method) {
-                    object[property] = wrappedMethod;
+                } else {
+                    Object.defineProperty(object, property, wrappedMethodDesc);
                 }
             };
 
             method.restore.sinon = true;
-            mirrorProperties(method, wrappedMethod);
 
             return method;
         };

--- a/test/sinon/stub_test.js
+++ b/test/sinon/stub_test.js
@@ -519,11 +519,11 @@ buster.testCase("sinon.stub", {
             assert.isFunction(stub.restore);
         },
 
-        "throws if third argument is provided but not function": function () {
+        "throws if third argument is provided but not a function or proprety descriptor": function () {
             var object = this.object;
 
             assert.exception(function () {
-                sinon.stub(object, "method", {});
+                sinon.stub(object, "method", 1);
             }, "TypeError");
         },
 


### PR DESCRIPTION
This PR addresses #88. I didn't touch mock as I've read about the plans to remove it in 2.0.

I've tried to make as little modification to the existing codebase as possible, and integrated getters & setters by providing an additional `type` parameter, which can take the value `get` or `set`. Using `defineProperty` and friends also solves #690.

Example usage:

    var obj = {};
    Object.defineProperty(obj, 'property', {
      get: function(){
        return 1;
      },
      configurable: true
    });
    var stub = sinon.stub(obj, 'get', 'property', function(){return 2;});
    console.log(obj.property);
    stub.restore();

@cjohansen I understand that you're not really a fan of getters & setters, but a lot of people do have a need for this (see above issue). Since sinon is the best (and only) mocking framework around, I think that getter & setter support will really benefit the community.