### PR TITLE
Fix documentation for linting

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,7 +74,7 @@ The JSCS test will be run before unit tests in the CI environment, your build wi
 You can run the jscs test with
 
 ```
-$ $(npm bin)/jscs .
+$ npm run lint
 ```
 
 or if you have JSCS installed as a global


### PR DESCRIPTION
One note: There is a usage of the direct call to the `jscs` command in the travis configuration file. As this issue is only about the documentation I didn't change that.

Fixes #695.