### PR TITLE
Fix spy.calledWith(undefined) to return false if it was called without args

### DIFF
--- a/lib/sinon/call.js
+++ b/lib/sinon/call.js
@@ -36,7 +36,11 @@
             },
 
             calledWith: function calledWith() {
-                for (var i = 0, l = arguments.length; i < l; i += 1) {
+                var l = arguments.length;
+                if (l > this.args.length) {
+                    return false;
+                }
+                for (var i = 0; i < l; i += 1) {
                     if (!sinon.deepEqual(arguments[i], this.args[i])) {
                         return false;
                     }
@@ -46,7 +50,11 @@
             },
 
             calledWithMatch: function calledWithMatch() {
-                for (var i = 0, l = arguments.length; i < l; i += 1) {
+                var l = arguments.length;
+                if (l > this.args.length) {
+                    return false;
+                }
+                for (var i = 0; i < l; i += 1) {
                     var actual = this.args[i];
                     var expectation = arguments[i];
                     if (!sinon.match || !sinon.match(expectation).test(actual)) {

--- a/test/sinon/spy_test.js
+++ b/test/sinon/spy_test.js
@@ -44,6 +44,12 @@ if (typeof require === "function" && typeof module === "object") {
                 assert.isFalse(this.spy[method](1, 2, 3));
             },
 
+            "returns false if not called with undefined": function () {
+                this.spy();
+
+                assert.isFalse(this.spy[method](undefined));
+            },
+
             "returns true for partial match": function () {
                 this.spy(1, 3, 3);
                 this.spy(2);


### PR DESCRIPTION
Either this sneaked in somehow or it was never really working. I think this is a bug and here is the fix. Anything else to consider @cjohansen @mroderick?
