### PR TITLE
fix mismatches between @depends and require calls

### DIFF
--- a/lib/sinon/assert.js
+++ b/lib/sinon/assert.js
@@ -1,7 +1,7 @@
 /**
  * @depend times_in_words.js
  * @depend util/core.js
- * @depend stub.js
+ * @depend match.js
  * @depend format.js
  */
 /**
@@ -197,6 +197,7 @@
     function loadDependencies(require, exports, module) {
         var sinon = require("./util/core");
         require("./match");
+        require("./format");
         module.exports = makeApi(sinon);
     }
 

--- a/lib/sinon/behavior.js
+++ b/lib/sinon/behavior.js
@@ -321,6 +321,7 @@
 
     function loadDependencies(require, exports, module) {
         var sinon = require("./util/core");
+        require("./extend");
         module.exports = makeApi(sinon);
     }
 

--- a/lib/sinon/call.js
+++ b/lib/sinon/call.js
@@ -203,6 +203,7 @@
     function loadDependencies(require, exports, module) {
         var sinon = require("./util/core");
         require("./match");
+        require("./format");
         module.exports = makeApi(sinon);
     }
 

--- a/lib/sinon/collection.js
+++ b/lib/sinon/collection.js
@@ -1,5 +1,6 @@
 /**
  * @depend util/core.js
+ * @depend spy.js
  * @depend stub.js
  * @depend mock.js
  */

--- a/lib/sinon/extend.js
+++ b/lib/sinon/extend.js
@@ -1,5 +1,5 @@
 /**
- * @depend ../sinon.js
+ * @depend util/core.js
  */
 "use strict";
 

--- a/lib/sinon/format.js
+++ b/lib/sinon/format.js
@@ -1,5 +1,5 @@
 /**
- * @depend ../sinon.js
+ * @depend util/core.js
  */
 /**
  * Format functions

--- a/lib/sinon/log_error.js
+++ b/lib/sinon/log_error.js
@@ -1,5 +1,5 @@
 /**
- * @depend ../sinon.js
+ * @depend util/core.js
  */
 /**
  * Logs errors

--- a/lib/sinon/match.js
+++ b/lib/sinon/match.js
@@ -238,6 +238,7 @@
 
     function loadDependencies(require, exports, module) {
         var sinon = require("./util/core");
+        require("./typeOf");
         module.exports = makeApi(sinon);
     }
 

--- a/lib/sinon/mock.js
+++ b/lib/sinon/mock.js
@@ -1,7 +1,10 @@
 /**
  * @depend times_in_words.js
  * @depend util/core.js
+ * @depend call.js
  * @depend extend.js
+ * @depend match.js
+ * @depend spy.js
  * @depend stub.js
  * @depend format.js
  */
@@ -430,9 +433,14 @@
 
     function loadDependencies(require, exports, module) {
         var sinon = require("./util/core");
+        require("./times_in_words");
         require("./call");
+        require("./extend");
         require("./match");
         require("./spy");
+        require("./stub");
+        require("./format");
+
         module.exports = makeApi(sinon);
     }
 

--- a/lib/sinon/sandbox.js
+++ b/lib/sinon/sandbox.js
@@ -143,7 +143,8 @@
 
     function loadDependencies(require, exports, module) {
         var sinon = require("./util/core");
-        require("./util/fake_server");
+        require("./extend");
+        require("./util/fake_server_with_clock");
         require("./util/fake_timers");
         require("./collection");
         module.exports = makeApi(sinon);

--- a/lib/sinon/spy.js
+++ b/lib/sinon/spy.js
@@ -427,6 +427,9 @@
     function loadDependencies(require, exports, module) {
         var sinon = require("./util/core");
         require("./call");
+        require("./extend");
+        require("./times_in_words");
+        require("./format");
         module.exports = makeApi(sinon);
     }
 

--- a/lib/sinon/stub.js
+++ b/lib/sinon/stub.js
@@ -154,6 +154,7 @@
         var sinon = require("./util/core");
         require("./behavior");
         require("./spy");
+        require("./extend");
         module.exports = makeApi(sinon);
     }
 

--- a/lib/sinon/test.js
+++ b/lib/sinon/test.js
@@ -1,7 +1,5 @@
 /**
  * @depend util/core.js
- * @depend stub.js
- * @depend mock.js
  * @depend sandbox.js
  */
 /**

--- a/lib/sinon/times_in_words.js
+++ b/lib/sinon/times_in_words.js
@@ -1,5 +1,5 @@
 /**
- * @depend ../sinon.js
+ * @depend util/core.js
  */
 "use strict";
 

--- a/lib/sinon/typeOf.js
+++ b/lib/sinon/typeOf.js
@@ -1,5 +1,5 @@
 /**
- * @depend ../sinon.js
+ * @depend util/core.js
  */
 /**
  * Format functions

--- a/lib/sinon/util/fake_server.js
+++ b/lib/sinon/util/fake_server.js
@@ -223,6 +223,7 @@ if (typeof sinon == "undefined") {
         var sinon = require("./core");
         require("./fake_xdomain_request");
         require("./fake_xml_http_request");
+        require("../format");
         makeApi(sinon);
         module.exports = sinon;
     }

--- a/lib/sinon/util/fake_timers.js
+++ b/lib/sinon/util/fake_timers.js
@@ -61,16 +61,16 @@ if (typeof sinon == "undefined") {
     var isNode = typeof module !== "undefined" && module.exports && typeof require == "function";
     var isAMD = typeof define === "function" && typeof define.amd === "object" && define.amd;
 
-    function loadDependencies(require, epxorts, module) {
+    function loadDependencies(require, epxorts, module, lolex) {
         var sinon = require("./core");
-        makeApi(sinon, require("lolex"));
+        makeApi(sinon, lolex);
         module.exports = sinon;
     }
 
     if (isAMD) {
         define(loadDependencies);
     } else if (isNode) {
-        loadDependencies(require, module.exports, module);
+        loadDependencies(require, module.exports, module, require("lolex"));
     } else {
         makeApi(sinon);
     }

--- a/lib/sinon/util/fake_xdomain_request.js
+++ b/lib/sinon/util/fake_xdomain_request.js
@@ -206,7 +206,9 @@ if (typeof sinon == "undefined") {
 
     function loadDependencies(require, exports, module) {
         var sinon = require("./core");
+        require("../extend");
         require("./event");
+        require("../log_error");
         makeApi(sinon);
         module.exports = sinon;
     }

--- a/lib/sinon/util/fake_xml_http_request.js
+++ b/lib/sinon/util/fake_xml_http_request.js
@@ -600,7 +600,9 @@
 
     function loadDependencies(require, exports, module) {
         var sinon = require("./core");
+        require("../extend");
         require("./event");
+        require("../log_error");
         makeApi(sinon);
         module.exports = sinon;
     }


### PR DESCRIPTION
i'm back! stuff is broken again...

i obviously don't update sinon often and it's because whenever i do, i find these kinds of problems and lose time having to fix them.

1. introducing lolex broke AMD because lolex doesn't load via AMD - it needs an extra build step or something... i don't know, i don't use it so i haven't figured it out but i can't load sinon from source via AMD because of it.  so, i've changed it to only load it (via `require("lolex")`) in node.  if someone wants to use it with AMD, they can load it with a script tag first or figure out how to make it work.
1. since i don't need lolex, i thought "no problem.  i can work around this by loading stub and spy directly and lolex won't even come into the picture".  unfortunately, when format, extend, etc were moved to their own modules, the calls to `require` were not added.

hopefully the dependencies can be kept working with keeping these things in mind:

1. nothing within sinon depends on sinon/lib/sinon.js - anything that needs a reference to the `sinon` handle gets it from sinon/lib/util/core.js or else there will be circular dependencies
1. the @depends annotations and the calls to `require` in `loadDependencies` need to be kept in sync.  ideally, you would do away with the annotations and just let the code dictate what the dependencies are so that you don't have to duplicate this but that's up to you.