### PR TITLE
Fix #702 async sinon.test using mocha interface

### DIFF
--- a/lib/sinon/test.js
+++ b/lib/sinon/test.js
@@ -62,7 +62,7 @@
             }
 
             if (callback.length) {
-                return function sinonAsyncSandboxedTest() {
+                return function sinonAsyncSandboxedTest(callback) {
                     return sinonSandboxedTest.apply(this, arguments);
                 };
             }

--- a/test/sinon/test_test.js
+++ b/test/sinon/test_test.js
@@ -137,6 +137,25 @@ buster.testCase("sinon.test", {
         }).call({}, fakeDone);
     },
 
+    "async test with sandbox using mocha interface": function (done) {
+        var it = function(title, fn) {
+            var mochaDone = function(args) {
+                assert.equals(args, undefined);
+                done(args);
+            };
+            if (fn.length) {
+                fn.call(this, mochaDone);
+            } else {
+                fn.call(this);
+            }
+        };
+        it("works", sinon.test(function (callback) {
+            buster.nextTick(function() {
+                callback();
+            });
+        }));
+    },
+
     "async test with sandbox and spy": function (done) {
         sinon.test(function (callback) {
             var globalObj = {

--- a/test/sinon/test_test.js
+++ b/test/sinon/test_test.js
@@ -138,8 +138,8 @@ buster.testCase("sinon.test", {
     },
 
     "async test with sandbox using mocha interface": function (done) {
-        var it = function(title, fn) {
-            var mochaDone = function(args) {
+        var it = function (title, fn) {
+            var mochaDone = function (args) {
                 assert.equals(args, undefined);
                 done(args);
             };
@@ -150,7 +150,7 @@ buster.testCase("sinon.test", {
             }
         };
         it("works", sinon.test(function (callback) {
-            buster.nextTick(function() {
+            buster.nextTick(function () {
                 callback();
             });
         }));


### PR DESCRIPTION
on v1.13.0 using mocha

```js
describe("sinon.test", function() {
  it("works", sinon.test(function(done) {
    done();
  });
});
```

excepted: pass the test
but got: `Uncaught ReferenceError: done is not defined`

