### PR TITLE
Fallback for .restore() native code functions on Chrome & PhantomJS

### DIFF
--- a/lib/sinon/util/core.js
+++ b/lib/sinon/util/core.js
@@ -131,7 +131,16 @@
                 // If this fails (ex: localStorage on mobile safari) then force a reset
                 // via direct assignment.
                 if (!owned) {
-                    delete object[property];
+                    try {
+                        delete object[property];
+                    } catch (e) {}
+                    // For native code functions `delete` fails without throwing an error
+                    // on Chrome < 43, PhantomJS, etc.
+                    // Use strict equality comparison to check failures then force a reset
+                    // via direct assignment.
+                    if (object[property] === method) {
+                        object[property] = wrappedMethod;
+                    }
                 } else {
                     Object.defineProperty(object, property, wrappedMethodDesc);
                 }


### PR DESCRIPTION
This PR addresses a problem where .restore() does not restore native code functions on Chrome and PhantomJS.

#692 breaks restoring native code functions on Chrome and PhantomJS, but in fact it's caused by a bug in WebKit and it has been fixed in Chrome after 43.0.2375.5 dev.

However, considering PhantomJS is still using a buggy version of WebKit, I think it's better to put back the old way of restoring method as a fallback option.

---

How to reproduce the problem:

Expected behavior on Safari 8.0:

``` javascript
> document.body.appendChild
< function appendChild() { [native code] }

> sinon.stub(document.body, "appendChild")
< appendChild

> document.body.appendChild.restore()
< undefined

> document.body.appendChild
< function appendChild() { [native code] }

> sinon.stub(document.body, "appendChild")
< appendChild
```

On Chome 42 or PhantomJS 1.9.8:

``` javascript
> document.body.appendChild
< function appendChild() { [native code] }

> sinon.stub(document.body, "appendChild")
< appendChild

> document.body.appendChild.restore()
< undefined

> document.body.appendChild
< appendChild

> sinon.stub(document.body, "appendChild")
< TypeError: Attempted to wrap appendChild which is already wrapped
```
