### PR TITLE
Restore support for sinon in IE<9

### DIFF
--- a/lib/sinon/spy.js
+++ b/lib/sinon/spy.js
@@ -16,13 +16,6 @@
 "use strict";
 
 (function (sinon) {
-    function getPropertyDescriptor(object, property) {
-        var proto = object, descriptor;
-        while (proto && !(descriptor = Object.getOwnPropertyDescriptor(proto, property))) {
-            proto = Object.getPrototypeOf(proto);
-        }
-        return descriptor;
-    }
 
     function makeApi(sinon) {
         var push = Array.prototype.push;
@@ -39,7 +32,7 @@
             }
 
             if (types) {
-                var methodDesc = getPropertyDescriptor(object, property);
+                var methodDesc = sinon.getPropertyDescriptor(object, property);
                 for (var i = 0; i < types.length; i++) {
                     methodDesc[types[i]] = spy.create(methodDesc[types[i]]);
                 }

--- a/lib/sinon/stub.js
+++ b/lib/sinon/stub.js
@@ -29,7 +29,7 @@
                 } else {
                     wrapper = func;
                     if (sinon.spy && sinon.spy.create) {
-                        var types = Object.keys(wrapper);
+                        var types = sinon.objectKeys(wrapper);
                         for (var i = 0; i < types.length; i++) {
                             wrapper[types[i]] = sinon.spy.create(wrapper[types[i]]);
                         }

--- a/lib/sinon/util/core.js
+++ b/lib/sinon/util/core.js
@@ -15,14 +15,6 @@
     var div = typeof document != "undefined" && document.createElement("div");
     var hasOwn = Object.prototype.hasOwnProperty;
 
-    function getPropertyDescriptor(object, property) {
-        var proto = object, descriptor;
-        while (proto && !(descriptor = Object.getOwnPropertyDescriptor(proto, property))) {
-            proto = Object.getPrototypeOf(proto);
-        }
-        return descriptor;
-    }
-
     function isDOMNode(obj) {
         var success = false;
 
@@ -66,6 +58,9 @@
         return typeof obj === "function" && typeof obj.restore === "function" && obj.restore.sinon;
     }
 
+    // Cheap way to detect if we have ES5 support.
+    var hasES5Support = "keys" in Object;
+
     function makeApi(sinon) {
         sinon.wrapMethod = function wrapMethod(object, property, method) {
             if (!object) {
@@ -75,26 +70,8 @@
             if (typeof method != "function" && typeof method != "object") {
                 throw new TypeError("Method wrapper should be a function or a property descriptor");
             }
-            var methodDesc = (typeof method == "function") ? {value: method} : method,
-                wrappedMethodDesc = getPropertyDescriptor(object, property),
-                error, i, wrappedMethod;
 
-            if (!wrappedMethodDesc) {
-                error = new TypeError("Attempted to wrap " + (typeof wrappedMethod) + " property " +
-                                    property + " as function");
-            } else if (wrappedMethodDesc.restore && wrappedMethodDesc.restore.sinon) {
-                error = new TypeError("Attempted to wrap " + property + " which is already wrapped");
-            }
-            if (error) {
-                if (wrappedMethodDesc && wrappedMethodDesc.stackTrace) {
-                    error.stack += "\n--------------\n" + wrappedMethodDesc.stackTrace;
-                }
-                throw error;
-            }
-
-            var types = Object.keys(methodDesc);
-            for (i = 0; i < types.length; i++) {
-                wrappedMethod = wrappedMethodDesc[types[i]];
+            function checkWrappedMethod(wrappedMethod) {
                 if (!isFunction(wrappedMethod)) {
                     error = new TypeError("Attempted to wrap " + (typeof wrappedMethod) + " property " +
                                         property + " as function");
@@ -104,6 +81,7 @@
                     var verb = !!wrappedMethod.returns ? "stubbed" : "spied on";
                     error = new TypeError("Attempted to wrap " + property + " which is already " + verb);
                 }
+
                 if (error) {
                     if (wrappedMethod && wrappedMethod.stackTrace) {
                         error.stack += "\n--------------\n" + wrappedMethod.stackTrace;
@@ -112,16 +90,50 @@
                 }
             }
 
+            var error, wrappedMethod;
+
             // IE 8 does not support hasOwnProperty on the window object and Firefox has a problem
             // when using hasOwn.call on objects from other frames.
             var owned = object.hasOwnProperty ? object.hasOwnProperty(property) : hasOwn.call(object, property);
-            mirrorProperties(methodDesc, wrappedMethodDesc);
-            for (i = 0; i < types.length; i++) {
-                mirrorProperties(methodDesc[types[i]], wrappedMethodDesc[types[i]]);
+
+            if (hasES5Support) {
+                var methodDesc = (typeof method == "function") ? {value: method} : method,
+                    wrappedMethodDesc = sinon.getPropertyDescriptor(object, property),
+                    i;
+
+                if (!wrappedMethodDesc) {
+                    error = new TypeError("Attempted to wrap " + (typeof wrappedMethod) + " property " +
+                                        property + " as function");
+                } else if (wrappedMethodDesc.restore && wrappedMethodDesc.restore.sinon) {
+                    error = new TypeError("Attempted to wrap " + property + " which is already wrapped");
+                }
+                if (error) {
+                    if (wrappedMethodDesc && wrappedMethodDesc.stackTrace) {
+                        error.stack += "\n--------------\n" + wrappedMethodDesc.stackTrace;
+                    }
+                    throw error;
+                }
+
+                var types = sinon.objectKeys(methodDesc);
+                for (i = 0; i < types.length; i++) {
+                    wrappedMethod = wrappedMethodDesc[types[i]];
+                    checkWrappedMethod(wrappedMethod);
+                }
+
+                mirrorProperties(methodDesc, wrappedMethodDesc);
+                for (i = 0; i < types.length; i++) {
+                    mirrorProperties(methodDesc[types[i]], wrappedMethodDesc[types[i]]);
+                }
+                Object.defineProperty(object, property, methodDesc);
+            } else {
+                wrappedMethod = object[property];
+                checkWrappedMethod(wrappedMethod);
+                object[property] = method;
+                method.displayName = property;
             }
-            Object.defineProperty(object, property, methodDesc);
 
             method.displayName = property;
+
             // Set up a stack trace which can be used later to find what line of
             // code the original method was created on.
             method.stackTrace = (new Error("Stack Trace for original")).stack;
@@ -141,12 +153,20 @@
                     if (object[property] === method) {
                         object[property] = wrappedMethod;
                     }
-                } else {
+                } else if (hasES5Support) {
                     Object.defineProperty(object, property, wrappedMethodDesc);
+                }
+
+                if (!hasES5Support && object[property] === method) {
+                    object[property] = wrappedMethod;
                 }
             };
 
             method.restore.sinon = true;
+
+            if (!hasES5Support) {
+                mirrorProperties(method, wrappedMethod);
+            }
 
             return method;
         };
@@ -253,6 +273,30 @@
 
             return this.displayName || "sinon fake";
         };
+
+        sinon.objectKeys = function objectKeys(obj) {
+            if (obj !== Object(obj)) {
+                throw new TypeError("sinon.objectKeys called on a non-object");
+            }
+
+            var keys = [];
+            var key;
+            for (key in obj) {
+                if (hasOwn.call(obj, key)) {
+                    keys.push(key);
+                }
+            }
+
+            return keys;
+        };
+
+        sinon.getPropertyDescriptor = function getPropertyDescriptor(object, property) {
+            var proto = object, descriptor;
+            while (proto && !(descriptor = Object.getOwnPropertyDescriptor(proto, property))) {
+                proto = Object.getPrototypeOf(proto);
+            }
+            return descriptor;
+        }
 
         sinon.getConfig = function (custom) {
             var config = {};


### PR DESCRIPTION
This change mostly puts the changes in https://github.com/cjohansen/Sinon.JS/commit/bb467e66dc5aecbe71e7c32e1cf9968043b3b430 behind an `if` statement which is checking if the current environment has ES5 support.

I'm not wild about the branching behavior but unsure of another solution. At the very least this gets the best of both worlds for the time being.

All tests are passing at this time.

This resolves #712.