### PR TITLE
Update JSCS, fixes #707

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,17 +71,11 @@ Sinon.JS uses [JSCS](https://github.com/mdevils/node-jscs) to keep consistent st
 
 The JSCS test will be run before unit tests in the CI environment, your build will fail if it doesn't pass the style check.
 
-You can run the jscs test with
-
 ```
 $ npm run lint
 ```
 
-or if you have JSCS installed as a global
-
-```
-$ jscs .
-```
+To ensure consistent reporting of lint warnings, you should use the same version as CI environment (defined in `package.json`)
 
 ### Run the tests
 

--- a/lib/sinon/assert.js
+++ b/lib/sinon/assert.js
@@ -167,8 +167,9 @@
         };
 
         mirrorPropAsAssertion("called", "expected %n to have been called at least once but was never called");
-        mirrorPropAsAssertion("notCalled", function (spy) { return !spy.called; },
-                            "expected %n to not have been called but was called %c%C");
+        mirrorPropAsAssertion("notCalled", function (spy) {
+            return !spy.called;
+        }, "expected %n to not have been called but was called %c%C");
         mirrorPropAsAssertion("calledOnce", "expected %n to be called once but was called %c%C");
         mirrorPropAsAssertion("calledTwice", "expected %n to be called twice but was called %c%C");
         mirrorPropAsAssertion("calledThrice", "expected %n to be called thrice but was called %c%C");

--- a/lib/sinon/spy.js
+++ b/lib/sinon/spy.js
@@ -343,10 +343,12 @@
         delegateToCalls("alwaysCalledWithMatch", false, "calledWithMatch");
         delegateToCalls("calledWithExactly", true);
         delegateToCalls("alwaysCalledWithExactly", false, "calledWithExactly");
-        delegateToCalls("neverCalledWith", false, "notCalledWith",
-            function () { return true; });
-        delegateToCalls("neverCalledWithMatch", false, "notCalledWithMatch",
-            function () { return true; });
+        delegateToCalls("neverCalledWith", false, "notCalledWith", function () {
+            return true;
+        });
+        delegateToCalls("neverCalledWithMatch", false, "notCalledWithMatch", function () {
+            return true;
+        });
         delegateToCalls("threw", true);
         delegateToCalls("alwaysThrew", false, "threw");
         delegateToCalls("returned", true);

--- a/lib/sinon/test_case.js
+++ b/lib/sinon/test_case.js
@@ -41,11 +41,9 @@
 
     function makeApi(sinon) {
         function testCase(tests, prefix) {
-            /*jsl:ignore*/
             if (!tests || typeof tests != "object") {
                 throw new TypeError("sinon.testCase needs an object with test functions");
             }
-            /*jsl:end*/
 
             prefix = prefix || "test";
             var rPrefix = new RegExp("^" + prefix);
@@ -54,12 +52,8 @@
             var tearDown = tests.tearDown;
 
             for (testName in tests) {
-                if (tests.hasOwnProperty(testName)) {
+                if (tests.hasOwnProperty(testName) && !/^(setUp|tearDown)$/.test(testName)) {
                     property = tests[testName];
-
-                    if (/^(setUp|tearDown)$/.test(testName)) {
-                        continue;
-                    }
 
                     if (typeof property == "function" && rPrefix.test(testName)) {
                         method = property;

--- a/lib/sinon/util/fake_server.js
+++ b/lib/sinon/util/fake_server.js
@@ -151,7 +151,9 @@ if (typeof sinon == "undefined") {
                     return;
                 }
 
-                if (!this.responses) { this.responses = []; }
+                if (!this.responses) {
+                    this.responses = [];
+                }
 
                 if (arguments.length == 1) {
                     body = method;

--- a/lib/sinon/util/fake_xml_http_request.js
+++ b/lib/sinon/util/fake_xml_http_request.js
@@ -24,7 +24,9 @@
     sinonXhr.supportsActiveX = typeof sinonXhr.GlobalActiveXObject != "undefined";
     sinonXhr.supportsXHR = typeof sinonXhr.GlobalXMLHttpRequest != "undefined";
     sinonXhr.workingXHR = sinonXhr.supportsXHR ? sinonXhr.GlobalXMLHttpRequest : sinonXhr.supportsActiveX
-                                     ? function () { return new sinonXhr.GlobalActiveXObject("MSXML2.XMLHTTP.3.0") } : false;
+                                     ? function () {
+                                        return new sinonXhr.GlobalActiveXObject("MSXML2.XMLHTTP.3.0")
+                                    } : false;
     sinonXhr.supportsCORS = sinonXhr.supportsXHR && "withCredentials" in (new sinonXhr.GlobalXMLHttpRequest());
 
     /*jsl:ignore*/

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   ],
   "scripts": {
     "test": "node test/node/run.js",
-    "lint": "jscs **/*.js",
+    "lint": "jscs .",
     "prepublish": "./build"
   },
   "dependencies": {
@@ -35,7 +35,7 @@
     "buster-test": "~0.5",
     "buster-format": "~0.5.6",
     "http-server": "*",
-    "jscs": "~1.5.9"
+    "jscs": "1.11.3"
   },
   "main": "./lib/sinon.js",
   "engines": {

--- a/test/runner.js
+++ b/test/runner.js
@@ -32,13 +32,17 @@
         }
     };
 
-    if (asciiFormat) { buster.assertions.format = asciiFormat; }
+    if (asciiFormat) {
+        buster.assertions.format = asciiFormat;
+    }
     global.assert = buster.assertions.assert;
     global.refute = buster.assertions.refute;
 
     // Assertion counting
     var assertions = 0;
-    var count = function () { assertions += 1; };
+    var count = function () {
+        assertions += 1;
+    };
     buster.assertions.on("pass", count);
     buster.assertions.on("failure", count);
 
@@ -65,7 +69,9 @@
         });
     });
 
-    buster.testRunner.assertionCount = function () { return assertions; };
+    buster.testRunner.assertionCount = function () {
+        return assertions;
+    };
 
     var runner = buster.autoRun({
         cwd: typeof process != "undefined" ? process.cwd() : null

--- a/test/sinon/assert_test.js
+++ b/test/sinon/assert_test.js
@@ -65,8 +65,13 @@ buster.testCase("sinon.assert", {
     },
 
     ".match": {
-        setUp: function () { this.setUpStubs(); },
-        tearDown: function () { this.tearDownStubs(); },
+        setUp: function () {
+            this.setUpStubs();
+        },
+
+        tearDown: function () {
+            this.tearDownStubs();
+        },
 
         "fails when arguments to not match": function () {
             assert.exception(function () {
@@ -83,8 +88,13 @@ buster.testCase("sinon.assert", {
     },
 
     ".called": {
-        setUp: function () { this.setUpStubs(); },
-        tearDown: function () { this.tearDownStubs(); },
+        setUp: function () {
+            this.setUpStubs();
+        },
+
+        tearDown: function () {
+            this.tearDownStubs();
+        },
 
         "fails when method does not exist": function () {
             assert.exception(function () {
@@ -137,8 +147,13 @@ buster.testCase("sinon.assert", {
     },
 
     ".notCalled": {
-        setUp: function () { this.setUpStubs(); },
-        tearDown: function () { this.tearDownStubs(); },
+        setUp: function () {
+            this.setUpStubs();
+        },
+
+        tearDown: function () {
+            this.tearDownStubs();
+        },
 
         "fails when method does not exist": function () {
             assert.exception(function () {
@@ -187,8 +202,13 @@ buster.testCase("sinon.assert", {
     },
 
     ".calledOnce": {
-        setUp: function () { this.setUpStubs(); },
-        tearDown: function () { this.tearDownStubs(); },
+        setUp: function () {
+            this.setUpStubs();
+        },
+
+        tearDown: function () {
+            this.tearDownStubs();
+        },
 
         "fails when method does not exist": function () {
             assert.exception(function () {
@@ -250,8 +270,13 @@ buster.testCase("sinon.assert", {
     },
 
     ".calledTwice": {
-        setUp: function () { this.setUpStubs(); },
-        tearDown: function () { this.tearDownStubs(); },
+        setUp: function () {
+            this.setUpStubs();
+        },
+
+        tearDown: function () {
+            this.tearDownStubs();
+        },
 
         "fails if called once": function () {
             var stub = this.stub;
@@ -284,8 +309,13 @@ buster.testCase("sinon.assert", {
     },
 
     ".calledThrice": {
-        setUp: function () { this.setUpStubs(); },
-        tearDown: function () { this.tearDownStubs(); },
+        setUp: function () {
+            this.setUpStubs();
+        },
+
+        tearDown: function () {
+            this.tearDownStubs();
+        },
 
         "fails if called once": function () {
             var stub = this.stub;
@@ -320,8 +350,13 @@ buster.testCase("sinon.assert", {
     },
 
     ".callOrder": {
-        setUp: function () { this.setUpStubs(); },
-        tearDown: function () { this.tearDownStubs(); },
+        setUp: function () {
+            this.setUpStubs();
+        },
+
+        tearDown: function () {
+            this.tearDownStubs();
+        },
 
         "passes when calls where done in right order": function () {
             var spy1 = sinon.spy();
@@ -426,8 +461,13 @@ buster.testCase("sinon.assert", {
     },
 
     ".calledOn": {
-        setUp: function () { this.setUpStubs(); },
-        tearDown: function () { this.tearDownStubs(); },
+        setUp: function () {
+            this.setUpStubs();
+        },
+
+        tearDown: function () {
+            this.tearDownStubs();
+        },
 
         "fails when method does not exist": function () {
             var object = {};
@@ -486,8 +526,13 @@ buster.testCase("sinon.assert", {
     },
 
     ".calledWithNew": {
-        setUp: function () { this.setUpStubs(); },
-        tearDown: function () { this.tearDownStubs(); },
+        setUp: function () {
+            this.setUpStubs();
+        },
+
+        tearDown: function () {
+            this.tearDownStubs();
+        },
 
         "fails when method does not exist": function () {
             sinon.stub(this.stub, "calledWithNew");
@@ -541,8 +586,13 @@ buster.testCase("sinon.assert", {
     },
 
     ".alwaysCalledWithNew": {
-        setUp: function () { this.setUpStubs(); },
-        tearDown: function () { this.tearDownStubs(); },
+        setUp: function () {
+            this.setUpStubs();
+        },
+
+        tearDown: function () {
+            this.tearDownStubs();
+        },
 
         "fails when method does not exist": function () {
             sinon.stub(this.stub, "alwaysCalledWithNew");
@@ -596,8 +646,13 @@ buster.testCase("sinon.assert", {
     },
 
     ".calledWith": {
-        setUp: function () { this.setUpStubs(); },
-        tearDown: function () { this.tearDownStubs(); },
+        setUp: function () {
+            this.setUpStubs();
+        },
+
+        tearDown: function () {
+            this.tearDownStubs();
+        },
 
         "fails when method fails": function () {
             var object = {};
@@ -659,8 +714,13 @@ buster.testCase("sinon.assert", {
     },
 
     ".calledWithExactly": {
-        setUp: function () { this.setUpStubs(); },
-        tearDown: function () { this.tearDownStubs(); },
+        setUp: function () {
+            this.setUpStubs();
+        },
+
+        tearDown: function () {
+            this.tearDownStubs();
+        },
 
         "fails when method fails": function () {
             var object = {};
@@ -698,8 +758,13 @@ buster.testCase("sinon.assert", {
     },
 
     ".neverCalledWith": {
-        setUp: function () { this.setUpStubs(); },
-        tearDown: function () { this.tearDownStubs(); },
+        setUp: function () {
+            this.setUpStubs();
+        },
+
+        tearDown: function () {
+            this.tearDownStubs();
+        },
 
         "fails when method fails": function () {
             var object = {};
@@ -737,8 +802,13 @@ buster.testCase("sinon.assert", {
     },
 
     ".threwTest": {
-        setUp: function () { this.setUpStubs(); },
-        tearDown: function () { this.tearDownStubs(); },
+        setUp: function () {
+            this.setUpStubs();
+        },
+
+        tearDown: function () {
+            this.tearDownStubs();
+        },
 
         "fails when method fails": function () {
             sinon.stub(this.stub, "threw").returns(false);
@@ -775,8 +845,13 @@ buster.testCase("sinon.assert", {
     },
 
     ".callCount": {
-        setUp: function () { this.setUpStubs(); },
-        tearDown: function () { this.tearDownStubs(); },
+        setUp: function () {
+            this.setUpStubs();
+        },
+
+        tearDown: function () {
+            this.tearDownStubs();
+        },
 
         "fails when method fails": function () {
             this.stub();
@@ -811,8 +886,13 @@ buster.testCase("sinon.assert", {
     },
 
     ".alwaysCalledOn": {
-        setUp: function () { this.setUpStubs(); },
-        tearDown: function () { this.tearDownStubs(); },
+        setUp: function () {
+            this.setUpStubs();
+        },
+
+        tearDown: function () {
+            this.tearDownStubs();
+        },
 
         "fails if method is missing": function () {
             assert.exception(function () {
@@ -1169,8 +1249,16 @@ buster.testCase("sinon.assert", {
                 return "[Oh yeah]";
             };
 
-            var obj = { toString: function () { return "[Oh no]"; } };
-            var obj2 = { toString: function () { return "[Oh well]"; } };
+            var obj = {
+                toString: function () {
+                    return "[Oh no]";
+                }
+             };
+            var obj2 = {
+                toString: function () {
+                    return "[Oh well]";
+                }
+            };
 
             this.obj.doSomething.call(obj);
             this.obj.doSomething.call(obj2);
@@ -1184,8 +1272,16 @@ buster.testCase("sinon.assert", {
                 return "[Oh yeah]";
             };
 
-            var obj = { toString: function () { return "[Oh no]"; } };
-            var obj2 = { toString: function () { return "[Oh well]"; } };
+            var obj = {
+                toString: function () {
+                    return "[Oh no]";
+                }
+             };
+            var obj2 = {
+                toString: function () {
+                    return "[Oh well]";
+                }
+            };
 
             this.obj.doSomething.call(obj);
             this.obj.doSomething.call(obj2);

--- a/test/sinon/call_test.js
+++ b/test/sinon/call_test.js
@@ -1126,7 +1126,9 @@ if (typeof require === "function" && typeof module === "object") {
             },
 
             "initializes filtered spy with return values": function () {
-                var spy = sinon.spy(function (value) { return value; });
+                var spy = sinon.spy(function (value) {
+                    return value;
+                });
                 spy("a");
                 spy("b");
                 spy("b");

--- a/test/sinon/extend_test.js
+++ b/test/sinon/extend_test.js
@@ -25,8 +25,12 @@ buster.testCase("sinon.extend", {
     },
 
     "should copy toString method into target": function () {
-        var target = { hello: "world", toString: function () { return "hello world"; }},
-            source = { toString: function () { return "hello source"; }};
+        var target = { hello: "world", toString: function () {
+                return "hello world";
+            }},
+            source = { toString: function () {
+                return "hello source";
+            }};
 
         sinon.extend(target, source);
 

--- a/test/sinon/match_test.js
+++ b/test/sinon/match_test.js
@@ -248,13 +248,17 @@ buster.testCase("sinon.match", {
     },
 
     "returns true if test function in object returns true": function () {
-        var match = sinon.match({ test: function () { return true; }});
+        var match = sinon.match({ test: function () {
+            return true;
+        }});
 
         assert(match.test());
     },
 
     "returns false if test function in object returns false": function () {
-        var match = sinon.match({ test: function () { return false; }});
+        var match = sinon.match({ test: function () {
+            return false;
+        }});
 
         assert.isFalse(match.test());
     },
@@ -266,7 +270,9 @@ buster.testCase("sinon.match", {
     },
 
     "passes actual value to test function in object": function () {
-        var match = sinon.match({ test: function (arg) { return arg; }});
+        var match = sinon.match({ test: function (arg) {
+            return arg;
+        }});
 
         assert(match.test(true));
     },

--- a/test/sinon/sandbox_test.js
+++ b/test/sinon/sandbox_test.js
@@ -264,7 +264,9 @@ if (typeof require == "function" && typeof module == "object") {
 
             tearDown: function () {
                 sinon.useFakeTimers.restore();
-                if (sinon.fakeServer) { sinon.fakeServer.create.restore(); }
+                if (sinon.fakeServer) {
+                    sinon.fakeServer.create.restore();
+                }
             },
 
             "yields stub, mock as arguments": function () {

--- a/test/sinon/spy_test.js
+++ b/test/sinon/spy_test.js
@@ -551,14 +551,18 @@ if (typeof require === "function" && typeof module === "object") {
             },
 
             "is true if called with matcher that returns true": function () {
-                var matcher = sinon.match(function () { return true; });
+                var matcher = sinon.match(function () {
+                    return true;
+                });
                 this.spy();
 
                 assert(this.spy.calledOn(matcher));
             },
 
             "is false if called with matcher that returns false": function () {
-                var matcher = sinon.match(function () { return false; });
+                var matcher = sinon.match(function () {
+                    return false;
+                });
                 this.spy();
 
                 assert.isFalse(this.spy.calledOn(matcher));
@@ -672,7 +676,9 @@ if (typeof require === "function" && typeof module === "object") {
             },
 
             "is true newed constructor returns object": function () {
-                function MyThing() { return {}; }
+                function MyThing() {
+                    return {};
+                }
                 var object = { MyThing: MyThing };
                 sinon.spy(object, "MyThing");
 
@@ -1582,7 +1588,9 @@ if (typeof require === "function" && typeof module === "object") {
             },
 
             "is tracked even if exceptions are thrown": function () {
-                var spy = sinon.spy(function () { throw "an exception"; });
+                var spy = sinon.spy(function () {
+                    throw "an exception";
+                });
 
                 try {
                     spy();
@@ -1592,7 +1600,9 @@ if (typeof require === "function" && typeof module === "object") {
             },
 
             "has correct returnValue": function () {
-                var spy = sinon.spy(function () { return 42; });
+                var spy = sinon.spy(function () {
+                    return 42;
+                });
 
                 spy();
 
@@ -1602,7 +1612,9 @@ if (typeof require === "function" && typeof module === "object") {
 
             "has correct exception": function () {
                 var err = new Error();
-                var spy = sinon.spy(function () { throw err; });
+                var spy = sinon.spy(function () {
+                    throw err;
+                });
 
                 try {
                     spy();

--- a/test/sinon/stub_test.js
+++ b/test/sinon/stub_test.js
@@ -116,7 +116,9 @@ buster.testCase("sinon.stub", {
 
         "stub returns undefined when detached": {
             requiresSupportFor: {
-                strictMode: (function () { return this; }()) === undefined
+                strictMode: (function () {
+                    return this;
+                }()) === undefined
             },
             "": function () {
                 var stub = sinon.stub.create();
@@ -1177,7 +1179,9 @@ buster.testCase("sinon.stub", {
             stub.withArgs(42).throws();
 
             refute.exception(stub);
-            assert.exception(function () { stub(42); });
+            assert.exception(function () {
+                stub(42);
+            });
         }
     },
 

--- a/test/sinon/util/fake_server_with_clock_test.js
+++ b/test/sinon/util/fake_server_with_clock_test.js
@@ -14,7 +14,9 @@ buster.testCase("sinon.fakeServerWithClock", {
 
         tearDown: function () {
             this.server.restore();
-            if (this.clock) { this.clock.restore(); }
+            if (this.clock) {
+                this.clock.restore();
+            }
         },
 
         "calls 'super' when adding requests": sinon.test(function () {

--- a/test/sinon/util/fake_timers_test.js
+++ b/test/sinon/util/fake_timers_test.js
@@ -32,7 +32,9 @@ buster.testCase("sinon.clock", {
         "throws if no arguments": function () {
             var clock = this.clock;
 
-            assert.exception(function () { clock.setTimeout(); });
+            assert.exception(function () {
+                clock.setTimeout();
+            });
         },
 
         "returns numeric id or object with numeric id": function () {
@@ -87,7 +89,9 @@ buster.testCase("sinon.clock", {
         "calls correct timeout on recursive tick": function () {
             var clock = sinon.clock.create();
             var stub = sinon.stub.create();
-            var recurseCallback = function () { clock.tick(100); };
+            var recurseCallback = function () {
+                clock.tick(100);
+            };
 
             clock.setTimeout(recurseCallback, 50);
             clock.setTimeout(stub, 100);

--- a/test/sinon/util/fake_xml_http_request_test.js
+++ b/test/sinon/util/fake_xml_http_request_test.js
@@ -1093,7 +1093,9 @@
             "does not defake XHR requests that don't match a filter": function () {
                 sinon.stub(sinon.FakeXMLHttpRequest, "defake");
 
-                sinon.FakeXMLHttpRequest.addFilter(function () { return false; });
+                sinon.FakeXMLHttpRequest.addFilter(function () {
+                    return false;
+                });
                 new XMLHttpRequest().open("GET", "http://example.com");
 
                 refute(sinon.FakeXMLHttpRequest.defake.called);
@@ -1102,7 +1104,9 @@
             "defakes XHR requests that match a filter": function () {
                 sinon.stub(sinon.FakeXMLHttpRequest, "defake");
 
-                sinon.FakeXMLHttpRequest.addFilter(function () { return true; });
+                sinon.FakeXMLHttpRequest.addFilter(function () {
+                    return true;
+                });
                 new XMLHttpRequest().open("GET", "http://example.com");
 
                 assert(sinon.FakeXMLHttpRequest.defake.calledOnce);
@@ -1193,7 +1197,9 @@
                 sinon.FakeXMLHttpRequest.useFilters = true;
                 sinon.FakeXMLHttpRequest.filters = [];
                 sinon.useFakeXMLHttpRequest();
-                sinon.FakeXMLHttpRequest.addFilter(function () { return true; });
+                sinon.FakeXMLHttpRequest.addFilter(function () {
+                    return true;
+                });
             },
 
             tearDown: function () {

--- a/test/sinon_test.js
+++ b/test/sinon_test.js
@@ -144,7 +144,9 @@ buster.testCase("sinon", {
 
             "throws with stack trace showing original wrapMethod call": function () {
                 var object = { method: function () {} };
-                sinon.wrapMethod(object, "method", function () { return "original" });
+                sinon.wrapMethod(object, "method", function () {
+                    return "original"
+                });
 
                 try {
                     sinon.wrapMethod(object, "method", function () {});
@@ -631,7 +633,9 @@ buster.testCase("sinon", {
         },
 
         "has no side effects on the prototype": function () {
-            var proto = {method: function () {throw "error"}};
+            var proto = {method: function () {
+                throw "error"
+            }};
             var Class = function () {};
             Class.prototype = proto;
 


### PR DESCRIPTION
This PR updates JSCS to 1.11.3 (which is about six months younger than previous version used), and updates the lint task defined in package.json to lint all files (I still can't figure out why it behaves differently with `**/*.js` as file mask).

It also fixes all lint warnings reported by new linter.

This fixes #707 