### PR TITLE
Make fake server more readily customizable.

### DIFF
--- a/lib/sinon/util/fake_server.js
+++ b/lib/sinon/util/fake_server.js
@@ -23,70 +23,30 @@ if (typeof sinon == "undefined") {
 
 (function () {
     var push = [].push;
-    function F() {}
+
+    function RequestProcessor() {
+        this.requests = [];
+        var wloc = typeof window !== "undefined" ? window.location : {};
+        this.rCurrLoc = new RegExp("^" + wloc.protocol + "//" + wloc.host);
+        return this;
+    }
 
     function create(proto) {
-        F.prototype = proto;
-        return new F();
-    }
-
-    function responseArray(handler) {
-        var response = handler;
-
-        if (Object.prototype.toString.call(handler) != "[object Array]") {
-            response = [200, {}, handler];
-        }
-
-        if (typeof response[2] != "string") {
-            throw new TypeError("Fake server response body should be string, but was " +
-                                typeof response[2]);
-        }
-
-        return response;
-    }
-
-    var wloc = typeof window !== "undefined" ? window.location : {};
-    var rCurrLoc = new RegExp("^" + wloc.protocol + "//" + wloc.host);
-
-    function matchOne(response, reqMethod, reqUrl) {
-        var rmeth = response.method;
-        var matchMethod = !rmeth || rmeth.toLowerCase() == reqMethod.toLowerCase();
-        var url = response.url;
-        var matchUrl = !url || url == reqUrl || (typeof url.test == "function" && url.test(reqUrl));
-
-        return matchMethod && matchUrl;
-    }
-
-    function match(response, request) {
-        var requestUrl = request.url;
-
-        if (!/^https?:\/\//.test(requestUrl) || rCurrLoc.test(requestUrl)) {
-            requestUrl = requestUrl.replace(rCurrLoc, "");
-        }
-
-        if (matchOne(response, this.getHTTPMethod(request), requestUrl)) {
-            if (typeof response.response == "function") {
-                var ru = response.url;
-                var args = [request].concat(ru && typeof ru.exec == "function" ? ru.exec(requestUrl).slice(1) : []);
-                return response.response.apply(response, args);
-            }
-
-            return true;
-        }
-
-        return false;
+        RequestProcessor.prototype = proto;
+        return new RequestProcessor();
     }
 
     function makeApi(sinon) {
         sinon.fakeServer = {
+
             create: function () {
                 var server = create(this);
+
                 if (!sinon.xhr.supportsCORS) {
                     this.xhr = sinon.useFakeXDomainRequest();
                 } else {
                     this.xhr = sinon.useFakeXMLHttpRequest();
                 }
-                server.requests = [];
 
                 this.xhr.onCreate = function (xhrObj) {
                     server.addRequest(xhrObj);
@@ -145,9 +105,65 @@ if (typeof sinon == "undefined") {
                 sinon.log(str);
             },
 
+            matchOne: function (response, reqMethod, reqUrl) {
+                var rmeth = response.method;
+                var matchMethod = !rmeth || rmeth.toLowerCase() == reqMethod.toLowerCase();
+                var url = response.url;
+                var matchUrl = !url || url == reqUrl || (typeof url.test == "function" && url.test(reqUrl));
+
+                return matchMethod && matchUrl;
+            },
+
+            match: function (response, request) {
+                var requestUrl = request.url;
+
+                if (!/^https?:\/\//.test(requestUrl) || this.rCurrLoc.test(requestUrl)) {
+                    requestUrl = requestUrl.replace(this.rCurrLoc, "");
+                }
+
+                if (this.matchOne(response, this.getHTTPMethod(request), requestUrl)) {
+                    if (typeof response.response == "function") {
+                        var ru = response.url;
+                        var args = [request].concat(ru && typeof ru.exec == "function" ? ru.exec(requestUrl).slice(1) : []);
+                        return response.response.apply(response, args);
+                    }
+
+                    return true;
+                }
+
+                return false;
+            },
+
+            processRequest: function processRequest(request) {
+                try {
+                    if (request.aborted) {
+                        return;
+                    }
+
+                    var response = this.response || [404, {}, ""];
+
+                    if (this.responses) {
+                        for (var l = this.responses.length, i = l - 1; i >= 0; i--) {
+                            if (this.match(this.responses[i], request)) {
+                                response = this.responses[i].response;
+                                break;
+                            }
+                        }
+                    }
+
+                    if (request.readyState != 4) {
+                        this.log(response, request);
+
+                        request.respond(response[0], response[1], response[2]);
+                    }
+                } catch (e) {
+                    sinon.logError("Fake server request processing", e);
+                }
+            },
+
             respondWith: function respondWith(method, url, body) {
                 if (arguments.length == 1 && typeof method != "function") {
-                    this.response = responseArray(method);
+                    this.response = this.responseArray(method);
                     return;
                 }
 
@@ -169,7 +185,7 @@ if (typeof sinon == "undefined") {
                 push.call(this.responses, {
                     method: method,
                     url: url,
-                    response: typeof body == "function" ? body : responseArray(body)
+                    response: typeof body == "function" ? body : this.responseArray(body)
                 });
             },
 
@@ -187,31 +203,19 @@ if (typeof sinon == "undefined") {
                 }
             },
 
-            processRequest: function processRequest(request) {
-                try {
-                    if (request.aborted) {
-                        return;
-                    }
+            responseArray: function responseArray(handler) {
+                var response = handler;
 
-                    var response = this.response || [404, {}, ""];
-
-                    if (this.responses) {
-                        for (var l = this.responses.length, i = l - 1; i >= 0; i--) {
-                            if (match.call(this, this.responses[i], request)) {
-                                response = this.responses[i].response;
-                                break;
-                            }
-                        }
-                    }
-
-                    if (request.readyState != 4) {
-                        this.log(response, request);
-
-                        request.respond(response[0], response[1], response[2]);
-                    }
-                } catch (e) {
-                    sinon.logError("Fake server request processing", e);
+                if (Object.prototype.toString.call(handler) != "[object Array]") {
+                    response = [200, {}, handler];
                 }
+
+                if (typeof response[2] != "string") {
+                    throw new TypeError("Fake server response body should be string, but was " +
+                                        typeof response[2]);
+                }
+
+                return response;
             },
 
             restore: function restore() {


### PR DESCRIPTION
This is a step towards #498 by making more of the API to fakeServer more easily customizable.  From here I think it will be easier to go further to making request processing more pluggable.

It doesn't add any exising functionality so should be covered by existing tests.