### PR TITLE
Reorder events dispatched in `readyStateChange` in `FakeXMLHttpRequest`

### DIFF
--- a/lib/sinon/util/fake_xml_http_request.js
+++ b/lib/sinon/util/fake_xml_http_request.js
@@ -367,19 +367,19 @@
                     }
                 }
 
-                this.dispatchEvent(new sinon.Event("readystatechange"));
-
                 switch (this.readyState) {
                     case FakeXMLHttpRequest.DONE:
-                        this.dispatchEvent(new sinon.Event("load", false, false, this));
-                        this.dispatchEvent(new sinon.Event("loadend", false, false, this));
-                        this.upload.dispatchEvent(new sinon.Event("load", false, false, this));
                         if (supportsProgress) {
                             this.upload.dispatchEvent(new sinon.ProgressEvent("progress", {loaded: 100, total: 100}));
                             this.dispatchEvent(new sinon.ProgressEvent("progress", {loaded: 100, total: 100}));
                         }
+                        this.upload.dispatchEvent(new sinon.Event("load", false, false, this));
+                        this.dispatchEvent(new sinon.Event("load", false, false, this));
+                        this.dispatchEvent(new sinon.Event("loadend", false, false, this));
                         break;
                 }
+
+                this.dispatchEvent(new sinon.Event("readystatechange"));
             },
 
             setRequestHeader: function setRequestHeader(header, value) {

--- a/test/sinon/util/fake_xml_http_request_test.js
+++ b/test/sinon/util/fake_xml_http_request_test.js
@@ -1543,6 +1543,28 @@
                 this.xhr.respond(200, {}, "");
             },
 
+            "fires events in an order similar to a browser": function (done) {
+                var xhr = this.xhr,
+                    events = [];
+
+                this.xhr.upload.addEventListener("progress", function (e) {
+                    events.push(e.type);
+                });
+                this.xhr.upload.addEventListener("load", function (e) {
+                    events.push(e.type);
+                });
+                this.xhr.addEventListener("readystatechange", function (e) {
+                    if (xhr.readyState === 4) {
+                        events.push(e.type);
+                        assert.equals(events, ["progress", "load", "readystatechange"]);
+                        done();
+                    }
+                });
+
+                this.xhr.send();
+                this.xhr.respond(200, {}, "");
+            },
+
             "calls 'abort' on cancel": function (done) {
                 var xhr = this.xhr;
 


### PR DESCRIPTION
Event listeners for `progress`, `load` and `readyStateChange` function in  `FakeXMLHttpRequest` are dispatched in a different order in comparison to a browser. Reorder the events dispatched to reflect general browser behaviour.

Add a test to verify the dispatch order.