### PR TITLE
Don't stub getter properties

### DIFF
--- a/lib/sinon/stub.js
+++ b/lib/sinon/stub.js
@@ -49,7 +49,7 @@
 
             if (typeof property === "undefined" && typeof object == "object") {
                 for (var prop in object) {
-                    if (typeof object[prop] === "function") {
+                    if (typeof sinon.getPropertyDescriptor(object, prop).value === "function") {
                         stub(object, prop);
                     }
                 }

--- a/test/sinon/stub_test.js
+++ b/test/sinon/stub_test.js
@@ -637,6 +637,12 @@ buster.testCase("sinon.stub", {
 
         "only stubs functions": function () {
             var object = { foo: "bar" };
+            Object.defineProperty(object, "bar", {
+                get: function() {
+                    fail("Expected not to be called");
+                },
+                enumerable: true
+            });
             sinon.stub(object);
 
             assert.equals(object.foo, "bar");

--- a/test/sinon/stub_test.js
+++ b/test/sinon/stub_test.js
@@ -638,7 +638,7 @@ buster.testCase("sinon.stub", {
         "only stubs functions": function () {
             var object = { foo: "bar" };
             Object.defineProperty(object, "bar", {
-                get: function() {
+                get: function () {
                     fail("Expected not to be called");
                 },
                 enumerable: true


### PR DESCRIPTION
Sinon version : 1.14.1 Environment : node 0.12.2

I found that `sinon.createStubInstance` caused an error when the class has a getter property and the getter method uses a property initialized in the constructor.

Here is a code snippet to reproduce this error.
```javascript
var sinon = require('sinon');

function C(o) {
    this._o = o;
}

Object.defineProperty(C.prototype, 'v', {
    get: function() {
        return this._o.v;
    },
    enumerable: true
});

var s = sinon.createStubInstance(C);
```
Here are the error messages.
```
/tmp/t.js:9
        return this._o.v;
                      ^
TypeError: Cannot read property 'v' of undefined
    at C.Object.defineProperty.get [as v] (/tmp/t.js:9:23)
    at Object.stub (/tmp/node_modules/sinon/lib/sinon/stub.js:53:38)
    at Object.sinon.createStubInstance (/tmp/node_modules/sinon/lib/sinon/util/core.js:356:26)
```

This patch makes `sinon.stub` access properties using `getOwnPropertyDescriptor` and not to call getters on an object.

What do you think?