### PR TITLE
Improve RELEASE.md to reduce effort when cutting a new release

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,11 +1,38 @@
 # Rolling Sinon releases
 
-* Compile interesting highlights from `git log vX.Y.Z..master` into Changelog.md
-* Put new authors in AUTHORS
-* Update version in package.json
-* Commit and tag version
-* `npm publish`
-* Copy files into the static site:
+You'll need a working installation of [git-extras](https://github.com/tj/git-extras) for this.
+
+## Update Changelog.txt
+
+Compile interesting highlights from [`git changelog`](https://github.com/tj/git-extras/blob/master/Commands.md#git-changelog) into Changelog.md
+
+    git changelog --no-merges
+
+## Update AUTHORS
+
+    git authors --list > AUTHORS
+
+## Create a new version
+
+Update package.json and create a new tag.
+
+```
+$ npm version x.y.z
+```
+
+## Publish to NPM
+
+```
+$ npm publish
+```
+
+## Update static site
+
+### Copy files into the static site
+
     cp Changelog.txt ../sinon-docs/resources/public/.
     cp pkg/* ../sinon-docs/resources/public/releases/.
-* Publish the site: `cd ../sinon-docs && ./publish.sh`
+
+### Publish the site
+
+    cd ../sinon-docs && ./publish.sh


### PR DESCRIPTION
* Generate Changelog.txt via `git-extras`
* Generate AUTHORS file via `git-extras`
* Create new version via `npm version` (updates package.json and creates a tag)