### PR TITLE
Deprecate mock

### DIFF
--- a/lib/sinon/mock.js
+++ b/lib/sinon/mock.js
@@ -24,6 +24,10 @@
         var match = sinon.match;
 
         function mock(object) {
+            if (typeof console !== undefined && console.warn) {
+                console.warn("mock will be removed from Sinon.JS v2.0");
+            }
+
             if (!object) {
                 return sinon.expectation.create("Anonymous mock");
             }


### PR DESCRIPTION
Add a deprecation warning for whenever `mock` is called, saying that it will be removed in v2.0