### PR TITLE
Provide an empty `responseHeaders` after an aborted XHR

### DIFF
--- a/lib/sinon/util/fake_xml_http_request.js
+++ b/lib/sinon/util/fake_xml_http_request.js
@@ -447,6 +447,7 @@
                 this.responseText = null;
                 this.errorFlag = true;
                 this.requestHeaders = {};
+                this.responseHeaders = {};
 
                 if (this.readyState > FakeXMLHttpRequest.UNSENT && this.sendFlag) {
                     this.readyStateChange(FakeXMLHttpRequest.DONE);

--- a/test/stub-test.js
+++ b/test/stub-test.js
@@ -600,7 +600,7 @@
         },
 
         everything: {
-           "stubs all methods of object without property": function () {
+            "stubs all methods of object without property": function () {
                 var obj = {
                     func1: function () {},
                     func2: function () {},

--- a/test/util/fake-xml-http-request-test.js
+++ b/test/util/fake-xml-http-request-test.js
@@ -914,6 +914,22 @@
                 assert.equals(this.xhr.requestHeaders, {});
             },
 
+            "does not have undefined response headers": function () {
+                this.xhr.open("GET", "/");
+
+                this.xhr.abort();
+
+                assert.defined(this.xhr.responseHeaders);
+            },
+
+            "nulls response headers": function () {
+                this.xhr.open("GET", "/");
+
+                this.xhr.abort();
+
+                assert.equals(this.xhr.responseHeaders, {});
+            },
+
             "sets state to DONE if sent before": function () {
                 var readyState;
                 this.xhr.open("GET", "/");


### PR DESCRIPTION
Fixes issue #749

Also fixes a previously existing lint failure in `test/stub-test.js`.