### PR TITLE
update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,12 +12,7 @@
     "mail": "christian@cjohansen.no",
     "url": "http://github.com/cjohansen/Sinon.JS/issues"
   },
-  "licenses": [
-    {
-      "type": "BSD",
-      "url": "http://github.com/cjohansen/Sinon.JS/blob/master/LICENSE"
-    }
-  ],
+  "license": "BSD-3-Clause",
   "scripts": {
     "ci-test": "./scripts/ci-test.sh",
     "test": "npm run lint && ./scripts/ci-test.sh",


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/