### PR TITLE
Fixed bug where assertions don't handle functions that have a propert…

### DIFF
--- a/lib/sinon/assert.js
+++ b/lib/sinon/assert.js
@@ -30,7 +30,7 @@
                     assert.fail("fake is not a spy");
                 }
 
-                if (method.proxy) {
+                if (method.proxy && method.proxy.isSinonProxy) {
                     verifyIsStub(method.proxy);
                 } else {
                     if (typeof method != "function") {

--- a/lib/sinon/spy.js
+++ b/lib/sinon/spy.js
@@ -83,6 +83,7 @@
                     return p.invoke(func, this, slice.call(arguments));
                 };
             }
+            p.isSinonProxy = true;
             return p;
         }
 

--- a/test/assert-test.js
+++ b/test/assert-test.js
@@ -26,6 +26,20 @@
             assert.isObject(sinon.assert);
         },
 
+        "supports proxy property": function () {
+            var failed = false;
+            var api = { method: function () {} };
+            api.method.proxy = function () {};
+            sinon.spy(api, "method");
+            api.method();
+            try {
+                sinon.assert.calledOnce(api.method);
+            } catch (e) {
+                failed = true;
+            }
+            assert.isFalse(failed);
+        },
+
         ".fail": {
             setUp: function () {
                 this.exceptionName = sinon.assert.failException;


### PR DESCRIPTION
I was bitten when trying to spy on jQuery and then using sinon.assert.  This fixes the issue by signing the proxy created by the spy with a property named isSinonProxy.  Then the assertions check for the presence of the isSinonProxy property before assuming a property named proxy is a sinon proxy.