### PR TITLE
Add support for responseType=json

### DIFF
--- a/lib/sinon/util/fake_xml_http_request.js
+++ b/lib/sinon/util/fake_xml_http_request.js
@@ -53,6 +53,10 @@
     };
     /*jsl:end*/
 
+    // Note that for FakeXMLHttpRequest to work pre ES5
+    // we lose some of the alignment with the spec.
+    // To ensure as close a match as possible,
+    // set responseType before calling open, send or respond;
     function FakeXMLHttpRequest() {
         this.readyState = FakeXMLHttpRequest.UNSENT;
         this.requestHeaders = {};
@@ -60,6 +64,8 @@
         this.status = 0;
         this.statusText = "";
         this.upload = new UploadProgress();
+        this.responseType = "";
+        this.response = "";
         if (sinonXhr.supportsCORS) {
             this.withCredentials = false;
         }
@@ -341,6 +347,7 @@
                 this.username = username;
                 this.password = password;
                 this.responseText = null;
+                this.response = this.responseType === "json" ? null : "";
                 this.responseXML = null;
                 this.requestHeaders = {};
                 this.sendFlag = false;
@@ -433,6 +440,7 @@
 
                 this.errorFlag = false;
                 this.sendFlag = this.async;
+                this.response = this.responseType === "json" ? null : "";
                 this.readyStateChange(FakeXMLHttpRequest.OPENED);
 
                 if (typeof this.onSend == "function") {
@@ -445,6 +453,7 @@
             abort: function abort() {
                 this.aborted = true;
                 this.responseText = null;
+                this.response = this.responseType === "json" ? null : "";
                 this.errorFlag = true;
                 this.requestHeaders = {};
                 this.responseHeaders = {};
@@ -525,6 +534,7 @@
                     }
                 }
 
+                this.response = this.responseType === "json" ? JSON.parse(this.responseText) : this.responseText;
                 this.readyStateChange(FakeXMLHttpRequest.DONE);
             },
 

--- a/test/util/fake-xml-http-request-test.js
+++ b/test/util/fake-xml-http-request-test.js
@@ -990,6 +990,65 @@
             }
         },
 
+        ".response": {
+            requiresSupportFor: {
+                "browser": typeof window !== "undefined"
+            },
+            setUp: function () {
+                this.xhr = new sinon.FakeXMLHttpRequest();
+            },
+
+            "is initially the empty string if responseType !== 'json'": function () {
+                this.xhr.responseType = "arraybuffer";
+                this.xhr.open("GET", "/");
+                assert.isString(this.xhr.response);
+                assert.equals(this.xhr.response, "");
+            },
+
+            "is initially null if responseType === 'json'": function () {
+                this.xhr.responseType = "json";
+                this.xhr.open("GET", "/");
+                assert.isNull(this.xhr.response);
+            },
+
+            "is the empty string when the response body is empty": function () {
+                this.xhr.open("GET", "/");
+                this.xhr.send();
+
+                this.xhr.respond(200, {}, "");
+
+                assert.isString(this.xhr.response);
+                assert.equals(this.xhr.response, "");
+            },
+
+            "parses JSON for responseType='json'": function () {
+                this.xhr.responseType = "json";
+                this.xhr.open("GET", "/");
+                this.xhr.send();
+
+                this.xhr.respond(200, { "Content-Type": "application/json" },
+                                 JSON.stringify({foo: true}));
+
+                var response = this.xhr.response;
+                assert.isObject(response);
+                assert.isTrue(response.foo);
+            },
+
+            "does not parse JSON if responseType!='json'": function () {
+                this.xhr.open("GET", "/");
+                this.xhr.send();
+
+                var responseText = JSON.stringify({foo: true});
+
+                this.xhr.respond(200, { "Content-Type": "application/json" },
+                                 responseText);
+
+                var response = this.xhr.response;
+                assert.isString(response);
+                assert.equals(response, responseText);
+            }
+        },
+
         ".responseXML": {
             requiresSupportFor: {
                 "browser": typeof window !== "undefined"


### PR DESCRIPTION
When working with FakeXMLHttpRequest I found that there were several instances where my tests were failing because xhr.response wasn't correctly parsed as JSON.

I have added code to support setting responseType = "json" and return a response inline with the spec here: https://xhr.spec.whatwg.org/#dom-xmlhttprequest-responsetype

There are tests around this new functionality and nothing else is reporting as a fail.

Thanks for the great package!