### PR TITLE
Spy call: Capture the stack

### DIFF
--- a/lib/sinon/call.js
+++ b/lib/sinon/call.js
@@ -149,6 +149,11 @@
                     "' since no callback was passed.", args);
             },
 
+            getStackFrames: function () {
+                // Omit the error message and the two top stack frames in sinon itself:
+                return this.stack && this.stack.split("\n").slice(3);
+            },
+
             toString: function () {
                 var callStr = this.proxy.toString() + "(";
                 var args = [];

--- a/lib/sinon/call.js
+++ b/lib/sinon/call.js
@@ -175,6 +175,9 @@
                         callStr += "(" + this.exception.message + ")";
                     }
                 }
+                if (this.stack) {
+                    callStr += " " + this.getStackFrames()[0].replace(/^\s+/, "");
+                }
 
                 return callStr;
             }

--- a/lib/sinon/call.js
+++ b/lib/sinon/call.js
@@ -177,7 +177,7 @@
 
         callProto.invokeCallback = callProto.yield;
 
-        function createSpyCall(spy, thisValue, args, returnValue, exception, id) {
+        function createSpyCall(spy, thisValue, args, returnValue, exception, id, stack) {
             if (typeof id !== "number") {
                 throw new TypeError("Call id is not a number");
             }
@@ -188,6 +188,7 @@
             proxyCall.returnValue = returnValue;
             proxyCall.exception = exception;
             proxyCall.callId = id;
+            proxyCall.stack = stack;
 
             return proxyCall;
         }

--- a/lib/sinon/call.js
+++ b/lib/sinon/call.js
@@ -176,7 +176,8 @@
                     }
                 }
                 if (this.stack) {
-                    callStr += " " + this.getStackFrames()[0].replace(/^\s+/, "");
+                    callStr += this.getStackFrames()[0].replace(/^\s*(?:at\s+|@)?/, " at ");
+
                 }
 
                 return callStr;

--- a/lib/sinon/spy.js
+++ b/lib/sinon/spy.js
@@ -114,6 +114,7 @@
                 this.thisValues = [];
                 this.exceptions = [];
                 this.callIds = [];
+                this.stacks = [];
                 if (this.fakes) {
                     for (var i = 0; i < this.fakes.length; i++) {
                         this.fakes[i].reset();
@@ -185,6 +186,7 @@
 
                 push.call(this.exceptions, exception);
                 push.call(this.returnValues, returnValue);
+                push.call(this.stacks, new Error().stack);
 
                 // Make return value and exception available in the calls:
                 createCallProperties.call(this);
@@ -208,7 +210,7 @@
 
                 return sinon.spyCall(this, this.thisValues[i], this.args[i],
                                         this.returnValues[i], this.exceptions[i],
-                                        this.callIds[i]);
+                                        this.callIds[i], this.stacks[i]);
             },
 
             getCalls: function () {

--- a/test/assert-test.js
+++ b/test/assert-test.js
@@ -1123,7 +1123,7 @@
             "assert.notCalled exception message one call": function () {
                 this.obj.doSomething();
 
-                assert.equals(this.message("notCalled", this.obj.doSomething),
+                assert.equals(this.message("notCalled", this.obj.doSomething).replace(/ at.*/g, ""),
                               "expected doSomething to not have been called " +
                               "but was called once\n    doSomething()");
             },
@@ -1134,7 +1134,7 @@
                 this.obj.doSomething();
                 this.obj.doSomething();
 
-                assert.equals(this.message("notCalled", this.obj.doSomething),
+                assert.equals(this.message("notCalled", this.obj.doSomething).replace(/ at.*/g, ""),
                               "expected doSomething to not have been called " +
                               "but was called 4 times\n    doSomething()\n    " +
                               "doSomething()\n    doSomething()\n    doSomething()");
@@ -1146,7 +1146,7 @@
                 this.obj.doSomething(42, 1);
                 this.obj.doSomething();
 
-                assert.equals(this.message("notCalled", this.obj.doSomething),
+                assert.equals(this.message("notCalled", this.obj.doSomething).replace(/ at.*/g, ""),
                               "expected doSomething to not have been called " +
                               "but was called 4 times\n    doSomething()\n    " +
                               "doSomething(3)\n    doSomething(42, 1)\n    doSomething()");
@@ -1199,7 +1199,7 @@
             "assert.callCount exception message": function () {
                 this.obj.doSomething();
 
-                assert.equals(this.message("callCount", this.obj.doSomething, 3),
+                assert.equals(this.message("callCount", this.obj.doSomething, 3).replace(/ at.*/g, ""),
                               "expected doSomething to be called thrice but was called " +
                               "once\n    doSomething()");
             },
@@ -1208,13 +1208,13 @@
                 this.obj.doSomething();
                 this.obj.doSomething();
 
-                assert.equals(this.message("calledOnce", this.obj.doSomething),
+                assert.equals(this.message("calledOnce", this.obj.doSomething).replace(/ at.*/g, ""),
                               "expected doSomething to be called once but was called " +
                               "twice\n    doSomething()\n    doSomething()");
 
                 this.obj.doSomething();
 
-                assert.equals(this.message("calledOnce", this.obj.doSomething),
+                assert.equals(this.message("calledOnce", this.obj.doSomething).replace(/ at.*/g, ""),
                               "expected doSomething to be called once but was called " +
                               "thrice\n    doSomething()\n    doSomething()\n    doSomething()");
             },
@@ -1222,7 +1222,7 @@
             "assert.calledTwice exception message": function () {
                 this.obj.doSomething();
 
-                assert.equals(this.message("calledTwice", this.obj.doSomething),
+                assert.equals(this.message("calledTwice", this.obj.doSomething).replace(/ at.*/g, ""),
                               "expected doSomething to be called twice but was called " +
                               "once\n    doSomething()");
             },
@@ -1233,7 +1233,7 @@
                 this.obj.doSomething();
                 this.obj.doSomething();
 
-                assert.equals(this.message("calledThrice", this.obj.doSomething),
+                assert.equals(this.message("calledThrice", this.obj.doSomething).replace(/ at.*/g, ""),
                               "expected doSomething to be called thrice but was called 4 times\n    doSomething()\n    doSomething()\n    doSomething()\n    doSomething()");
             },
 
@@ -1302,7 +1302,7 @@
             "assert.calledWith exception message": function () {
                 this.obj.doSomething(1, 3, "hey");
 
-                assert.equals(this.message("calledWith", this.obj.doSomething, 4, 3, "hey"),
+                assert.equals(this.message("calledWith", this.obj.doSomething, 4, 3, "hey").replace(/ at.*/g, ""),
                               "expected doSomething to be called with arguments 4, 3, " +
                               "hey\n    doSomething(1, 3, hey)");
             },
@@ -1310,7 +1310,7 @@
             "assert.calledWith match.any exception message": function () {
                 this.obj.doSomething(true, true);
 
-                assert.equals(this.message("calledWith", this.obj.doSomething, sinon.match.any, false),
+                assert.equals(this.message("calledWith", this.obj.doSomething, sinon.match.any, false).replace(/ at.*/g, ""),
                               "expected doSomething to be called with arguments " +
                               "any, false\n    doSomething(true, true)");
             },
@@ -1318,7 +1318,7 @@
             "assert.calledWith match.defined exception message": function () {
                 this.obj.doSomething();
 
-                assert.equals(this.message("calledWith", this.obj.doSomething, sinon.match.defined),
+                assert.equals(this.message("calledWith", this.obj.doSomething, sinon.match.defined).replace(/ at.*/g, ""),
                               "expected doSomething to be called with arguments " +
                               "defined\n    doSomething()");
             },
@@ -1326,7 +1326,7 @@
             "assert.calledWith match.truthy exception message": function () {
                 this.obj.doSomething();
 
-                assert.equals(this.message("calledWith", this.obj.doSomething, sinon.match.truthy),
+                assert.equals(this.message("calledWith", this.obj.doSomething, sinon.match.truthy).replace(/ at.*/g, ""),
                              "expected doSomething to be called with arguments " +
                              "truthy\n    doSomething()");
             },
@@ -1334,7 +1334,7 @@
             "assert.calledWith match.falsy exception message": function () {
                 this.obj.doSomething(true);
 
-                assert.equals(this.message("calledWith", this.obj.doSomething, sinon.match.falsy),
+                assert.equals(this.message("calledWith", this.obj.doSomething, sinon.match.falsy).replace(/ at.*/g, ""),
                               "expected doSomething to be called with arguments " +
                               "falsy\n    doSomething(true)");
             },
@@ -1342,7 +1342,7 @@
             "assert.calledWith match.same exception message": function () {
                 this.obj.doSomething();
 
-                assert.equals(this.message("calledWith", this.obj.doSomething, sinon.match.same(1)),
+                assert.equals(this.message("calledWith", this.obj.doSomething, sinon.match.same(1)).replace(/ at.*/g, ""),
                               "expected doSomething to be called with arguments " +
                               "same(1)\n    doSomething()");
             },
@@ -1350,7 +1350,7 @@
             "assert.calledWith match.typeOf exception message": function () {
                 this.obj.doSomething();
 
-                assert.equals(this.message("calledWith", this.obj.doSomething, sinon.match.typeOf("string")),
+                assert.equals(this.message("calledWith", this.obj.doSomething, sinon.match.typeOf("string")).replace(/ at.*/g, ""),
                               "expected doSomething to be called with arguments " +
                               "typeOf(\"string\")\n    doSomething()");
             },
@@ -1358,7 +1358,7 @@
             "assert.calledWith match.instanceOf exception message": function () {
                 this.obj.doSomething();
 
-                assert.equals(this.message("calledWith", this.obj.doSomething, sinon.match.instanceOf(function CustomType() {})),
+                assert.equals(this.message("calledWith", this.obj.doSomething, sinon.match.instanceOf(function CustomType() {})).replace(/ at.*/g, ""),
                               "expected doSomething to be called with arguments " +
                               "instanceOf(CustomType)\n    doSomething()");
             },
@@ -1366,7 +1366,7 @@
             "assert.calledWith match object exception message": function () {
                 this.obj.doSomething();
 
-                assert.equals(this.message("calledWith", this.obj.doSomething, sinon.match({ some: "value", and: 123 })),
+                assert.equals(this.message("calledWith", this.obj.doSomething, sinon.match({ some: "value", and: 123 })).replace(/ at.*/g, ""),
                               "expected doSomething to be called with arguments " +
                               "match(some: value, and: 123)\n    doSomething()");
             },
@@ -1374,7 +1374,7 @@
             "assert.calledWith match boolean exception message": function () {
                 this.obj.doSomething();
 
-                assert.equals(this.message("calledWith", this.obj.doSomething, sinon.match(true)),
+                assert.equals(this.message("calledWith", this.obj.doSomething, sinon.match(true)).replace(/ at.*/g, ""),
                               "expected doSomething to be called with arguments " +
                               "match(true)\n    doSomething()");
             },
@@ -1382,7 +1382,7 @@
             "assert.calledWith match number exception message": function () {
                 this.obj.doSomething();
 
-                assert.equals(this.message("calledWith", this.obj.doSomething, sinon.match(123)),
+                assert.equals(this.message("calledWith", this.obj.doSomething, sinon.match(123)).replace(/ at.*/g, ""),
                               "expected doSomething to be called with arguments " +
                               "match(123)\n    doSomething()");
             },
@@ -1390,7 +1390,7 @@
             "assert.calledWith match string exception message": function () {
                 this.obj.doSomething();
 
-                assert.equals(this.message("calledWith", this.obj.doSomething, sinon.match("Sinon")),
+                assert.equals(this.message("calledWith", this.obj.doSomething, sinon.match("Sinon")).replace(/ at.*/g, ""),
                               "expected doSomething to be called with arguments " +
                               "match(\"Sinon\")\n    doSomething()");
             },
@@ -1398,7 +1398,7 @@
             "assert.calledWith match regexp exception message": function () {
                 this.obj.doSomething();
 
-                assert.equals(this.message("calledWith", this.obj.doSomething, sinon.match(/[a-z]+/)),
+                assert.equals(this.message("calledWith", this.obj.doSomething, sinon.match(/[a-z]+/)).replace(/ at.*/g, ""),
                               "expected doSomething to be called with arguments " +
                               "match(/[a-z]+/)\n    doSomething()");
             },
@@ -1406,7 +1406,7 @@
             "assert.calledWith match test function exception message": function () {
                 this.obj.doSomething();
 
-                assert.equals(this.message("calledWith", this.obj.doSomething, sinon.match({ test: function custom() {} })),
+                assert.equals(this.message("calledWith", this.obj.doSomething, sinon.match({ test: function custom() {} })).replace(/ at.*/g, ""),
                               "expected doSomething to be called with arguments " +
                               "match(custom)\n    doSomething()");
             },
@@ -1414,7 +1414,7 @@
             "assert.calledWithMatch exception message": function () {
                 this.obj.doSomething(1, 3, "hey");
 
-                assert.equals(this.message("calledWithMatch", this.obj.doSomething, 4, 3, "hey"),
+                assert.equals(this.message("calledWithMatch", this.obj.doSomething, 4, 3, "hey").replace(/ at.*/g, ""),
                               "expected doSomething to be called with match 4, 3, " +
                               "hey\n    doSomething(1, 3, hey)");
             },
@@ -1423,7 +1423,7 @@
                 this.obj.doSomething(1, 3, "hey");
                 this.obj.doSomething(1, "hey");
 
-                assert.equals(this.message("alwaysCalledWith", this.obj.doSomething, 1, "hey"),
+                assert.equals(this.message("alwaysCalledWith", this.obj.doSomething, 1, "hey").replace(/ at.*/g, ""),
                               "expected doSomething to always be called with arguments 1" +
                               ", hey\n    doSomething(1, 3, hey)\n    doSomething(1, hey)");
             },
@@ -1432,7 +1432,7 @@
                 this.obj.doSomething(1, 3, "hey");
                 this.obj.doSomething(1, "hey");
 
-                assert.equals(this.message("alwaysCalledWithMatch", this.obj.doSomething, 1, "hey"),
+                assert.equals(this.message("alwaysCalledWithMatch", this.obj.doSomething, 1, "hey").replace(/ at.*/g, ""),
                               "expected doSomething to always be called with match 1" +
                               ", hey\n    doSomething(1, 3, hey)\n    doSomething(1, hey)");
             },
@@ -1440,7 +1440,7 @@
             "assert.calledWithExactly exception message": function () {
                 this.obj.doSomething(1, 3, "hey");
 
-                assert.equals(this.message("calledWithExactly", this.obj.doSomething, 1, 3),
+                assert.equals(this.message("calledWithExactly", this.obj.doSomething, 1, 3).replace(/ at.*/g, ""),
                               "expected doSomething to be called with exact arguments 1" +
                               ", 3\n    doSomething(1, 3, hey)");
             },
@@ -1449,7 +1449,7 @@
                 this.obj.doSomething(1, 3, "hey");
                 this.obj.doSomething(1, 3);
 
-                assert.equals(this.message("alwaysCalledWithExactly", this.obj.doSomething, 1, 3),
+                assert.equals(this.message("alwaysCalledWithExactly", this.obj.doSomething, 1, 3).replace(/ at.*/g, ""),
                               "expected doSomething to always be called with exact " +
                               "arguments 1, 3\n    doSomething(1, 3, hey)\n    " +
                               "doSomething(1, 3)");
@@ -1458,7 +1458,7 @@
             "assert.neverCalledWith exception message": function () {
                 this.obj.doSomething(1, 2, 3);
 
-                assert.equals(this.message("neverCalledWith", this.obj.doSomething, 1, 2),
+                assert.equals(this.message("neverCalledWith", this.obj.doSomething, 1, 2).replace(/ at.*/g, ""),
                               "expected doSomething to never be called with " +
                               "arguments 1, 2\n    doSomething(1, 2, 3)");
             },
@@ -1466,7 +1466,7 @@
             "assert.neverCalledWithMatch exception message": function () {
                 this.obj.doSomething(1, 2, 3);
 
-                assert.equals(this.message("neverCalledWithMatch", this.obj.doSomething, 1, 2),
+                assert.equals(this.message("neverCalledWithMatch", this.obj.doSomething, 1, 2).replace(/ at.*/g, ""),
                               "expected doSomething to never be called with match " +
                               "1, 2\n    doSomething(1, 2, 3)");
             },
@@ -1475,7 +1475,7 @@
                 this.obj.doSomething(1, 3, "hey");
                 this.obj.doSomething(1, 3);
 
-                assert.equals(this.message("threw", this.obj.doSomething),
+                assert.equals(this.message("threw", this.obj.doSomething).replace(/ at.*/g, ""),
                               "doSomething did not throw exception\n" +
                               "    doSomething(1, 3, hey)\n    doSomething(1, 3)");
             },
@@ -1484,7 +1484,7 @@
                 this.obj.doSomething(1, 3, "hey");
                 this.obj.doSomething(1, 3);
 
-                assert.equals(this.message("alwaysThrew", this.obj.doSomething),
+                assert.equals(this.message("alwaysThrew", this.obj.doSomething).replace(/ at.*/g, ""),
                               "doSomething did not always throw exception\n" +
                               "    doSomething(1, 3, hey)\n    doSomething(1, 3)");
             },

--- a/test/call-test.js
+++ b/test/call-test.js
@@ -749,35 +749,35 @@
                 var object = { doIt: sinon.spy() };
                 object.doIt();
 
-                assert.equals(object.doIt.getCall(0).toString(), "doIt()");
+                assert.equals(object.doIt.getCall(0).toString().replace(/ at.*/g, ""), "doIt()");
             },
 
             "includes single argument": function () {
                 var object = { doIt: sinon.spy() };
                 object.doIt(42);
 
-                assert.equals(object.doIt.getCall(0).toString(), "doIt(42)");
+                assert.equals(object.doIt.getCall(0).toString().replace(/ at.*/g, ""), "doIt(42)");
             },
 
             "includes all arguments": function () {
                 var object = { doIt: sinon.spy() };
                 object.doIt(42, "Hey");
 
-                assert.equals(object.doIt.getCall(0).toString(), "doIt(42, Hey)");
+                assert.equals(object.doIt.getCall(0).toString().replace(/ at.*/g, ""), "doIt(42, Hey)");
             },
 
             "includes explicit return value": function () {
                 var object = { doIt: sinon.stub().returns(42) };
                 object.doIt(42, "Hey");
 
-                assert.equals(object.doIt.getCall(0).toString(), "doIt(42, Hey) => 42");
+                assert.equals(object.doIt.getCall(0).toString().replace(/ at.*/g, ""), "doIt(42, Hey) => 42");
             },
 
             "includes empty string return value": function () {
                 var object = { doIt: sinon.stub().returns("") };
                 object.doIt(42, "Hey");
 
-                assert.equals(object.doIt.getCall(0).toString(), "doIt(42, Hey) => ");
+                assert.equals(object.doIt.getCall(0).toString().replace(/ at.*/g, ""), "doIt(42, Hey) => ");
             },
 
             "includes exception": function () {
@@ -787,7 +787,7 @@
                     object.doIt();
                 } catch (e) {}
 
-                assert.equals(object.doIt.getCall(0).toString(), "doIt() !TypeError");
+                assert.equals(object.doIt.getCall(0).toString().replace(/ at.*/g, ""), "doIt() !TypeError");
             },
 
             "includes exception message if any": function () {
@@ -797,7 +797,7 @@
                     object.doIt();
                 } catch (e) {}
 
-                assert.equals(object.doIt.getCall(0).toString(), "doIt() !TypeError(Oh noes!)");
+                assert.equals(object.doIt.getCall(0).toString().replace(/ at.*/g, ""), "doIt() !TypeError(Oh noes!)");
             },
 
             "formats arguments with sinon.format": function () {
@@ -806,7 +806,7 @@
 
                 object.doIt(42);
 
-                assert.equals(object.doIt.getCall(0).toString(), "doIt(Forty-two)");
+                assert.equals(object.doIt.getCall(0).toString().replace(/ at.*/g, ""), "doIt(Forty-two)");
                 assert(sinon.format.calledWith(42));
             },
 
@@ -816,7 +816,7 @@
 
                 object.doIt();
 
-                assert.equals(object.doIt.getCall(0).toString(), "doIt() => Forty-two");
+                assert.equals(object.doIt.getCall(0).toString().replace(/ at.*/g, ""), "doIt() => Forty-two");
                 assert(sinon.format.calledWith(42));
             }
         },
@@ -1209,7 +1209,7 @@
                     function test(arg, expected) {
                         var spy = sinon.spy();
                         spy(arg);
-                        assert.equals(spy.printf("%C"), "\n    " + expected);
+                        assert.equals(spy.printf("%C").replace(/ at.*/g, ""), "\n    " + expected);
                     }
 
                     test(true, "spy(true)");
@@ -1232,7 +1232,7 @@
                     spy(str);
                     spy(str);
 
-                    assert.equals(spy.printf("%C"),
+                    assert.equals(spy.printf("%C").replace(/ at.*/g, ""),
                         "\n    spy(" + str + ")" +
                         "\n\n    spy(" + str + ")" +
                         "\n\n    spy(" + str + ")");
@@ -1243,7 +1243,7 @@
                     spy("spy\ntest");
                     spy("spy\ntest");
 
-                    assert.equals(spy.printf("%C"),
+                    assert.equals(spy.printf("%C").replace(/ at.*/g, ""),
                         "\n    spy(test)" +
                         "\n    spy(" + str + ")" +
                         "\n\n    spy(" + str + ")");


### PR DESCRIPTION
I tried implementing my suggestion from #747 and added the top stack frame to the `spyCall.toString()` output.