### PR TITLE
Add callsFake

### DIFF
--- a/lib/sinon/behavior.js
+++ b/lib/sinon/behavior.js
@@ -137,7 +137,12 @@
             },
 
             invoke: function invoke(context, args) {
-                callCallback(this, args);
+
+                if (this.callFakeFn) {
+                    this.callFakeFn.apply(null, args);
+                } else {
+                    callCallback(this, args);
+                }
 
                 if (this.exception) {
                     throw this.exception;
@@ -170,7 +175,10 @@
                 throw new Error("Defining a stub by invoking \"stub.onCall(...).withArgs(...)\" is not supported. " +
                                 "Use \"stub.withArgs(...).onCall(...)\" to define sequential behavior for calls with certain arguments.");
             },
-
+            callsFake: function callsFake(fn) {
+                this.callFakeFn = fn;
+                return this;
+            },
             callsArg: function callsArg(pos) {
                 if (typeof pos != "number") {
                     throw new TypeError("argument index is not number");

--- a/test/stub-test.js
+++ b/test/stub-test.js
@@ -222,10 +222,10 @@
           },
 
           "calls fake function" : function () {
-              var callback = sinon.stub.create();
-              this.stub.callsFake(callback);
-              this.stub(1, 2, callback);
-              assert(callback.called);
+              var fake = sinon.stub.create();
+              this.stub.callsFake(fake);
+              this.stub(1, 2);
+              assert(fake.calledWith(1, 2));
           }
         },
         ".callsArg": {

--- a/test/stub-test.js
+++ b/test/stub-test.js
@@ -215,7 +215,19 @@
                 }
             }
         },
+        ".callsFake" : {
 
+          setUp: function () {
+              this.stub = sinon.stub.create();
+          },
+
+          "calls fake function" : function () {
+              var callback = sinon.stub.create();
+              this.stub.callsFake(callback);
+              this.stub(1, 2, callback);
+              assert(callback.called);
+          }
+        },
         ".callsArg": {
             setUp: function () {
                 this.stub = sinon.stub.create();


### PR DESCRIPTION
This adds `callsFake` function similar to the [jasmine's callFake](http://jasmine.github.io/2.0/introduction.html#section-Spies:_<code>and.callFake</code>)

The benefits of such a function is that you can add a mock function inline with the parameters of the function declared. I find this easier to read than `callsArgWith` as this requires you to think about the function you want to mock in a different way. I find it more natural and readable sometimes to drop in a replacement function.

example: 
   
```javascript

    var foo = {
       bar: function(a, b, c){
           // do stuff..
           return 'baz';
        },
        barWithCallback: function(a, callback){
          callback(null, 'ok');
        }
    }

    foo.bar = sinon.stub.create().callsFake(function(a, b, c){
      return 'baz';  
    });

    //more readable than callsArgWith(1, null, 'ok');?
    foo.barWithCallback = sinon.stub.create().callsFake(function(a, callback){
      callback(null, 'ok');
    });

   
```