### PR TITLE
Add pre-commit hook to validate staged files with JSCS

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,6 +79,8 @@ Node installed, and install Sinon's dependencies:
 
     $ npm install
 
+This will also install a pre-commit hook, that runs style validation on staged files.
+
 #### PhantomJS
 
 In order to run the tests, you'll need a [PhantomJS](http://phantomjs.org) global.

--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
   },
   "license": "BSD-3-Clause",
   "scripts": {
-    "ci-test": "./scripts/ci-test.sh",
-    "test": "npm run lint && ./scripts/ci-test.sh",
+    "ci-test": "$(npm bin)/jscs . && ./scripts/ci-test.sh",
+    "test": "./scripts/ci-test.sh",
     "lint": "$(npm bin)/jscs .",
     "prepublish": "./build",
     "jscs-pre-commit" : "./scripts/jscs-pre-commit"

--- a/package.json
+++ b/package.json
@@ -17,8 +17,12 @@
     "ci-test": "./scripts/ci-test.sh",
     "test": "npm run lint && ./scripts/ci-test.sh",
     "lint": "$(npm bin)/jscs .",
-    "prepublish": "./build"
+    "prepublish": "./build",
+    "jscs-pre-commit" : "./scripts/jscs-pre-commit"
   },
+  "pre-commit": [
+    "jscs-pre-commit"
+  ],
   "dependencies": {
     "formatio": "1.1.1",
     "util": ">=0.10.3 <1",
@@ -28,7 +32,8 @@
   "devDependencies": {
     "buster": "0.7.18",
     "buster-istanbul": "0.1.13",
-    "jscs": "1.13.1"
+    "jscs": "1.13.1",
+    "pre-commit": "1.0.10"
   },
   "files": [
     "lib",

--- a/scripts/jscs-pre-commit
+++ b/scripts/jscs-pre-commit
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+# Adapted from
+# https://raw.githubusercontent.com/flightjs/flight/master/jscs-pre-commit
+
+export JSCS_PATH='node_modules/.bin/jscs'
+
+# Extract staged files to a temp directory
+TMPDIR=
+TMPFILE=
+if [ "$IS_LINUX" == "true" ]; then
+    TMPFILE=`mktemp jscs_tmp_XXXXXX`
+    TMPDIR=`mktemp -d jscs_tmp_XXXXXX`
+else
+    TMPFILE=`mktemp -t tmp/jscs_tmp_XXXXXX`
+    TMPDIR=`mktemp -t tmp/jscs_tmp -d`
+fi
+git diff --cached --name-only --diff-filter=ACMR | xargs git checkout-index --prefix=$TMPDIR/ --
+
+# Check JavaScript code style
+RUN_JSCS=1
+TOTAL_ERRORS=0
+PLURAL_SUFFIX=
+
+JSFILES=$(git diff-index --name-status --cached HEAD | grep -v ^D | egrep '.js$' | cut -c3-)
+if [ -z "$JSFILES" ]; then
+    # No JavaScript file changed for this commit
+    RUN_JSCS=0
+elif [ -z "$JSCS_PATH" ]; then
+    echo -e "\033[0;31mIf you \033[1;34mnpm install jscs -g\033[0;31m I'll check your JS style\033[0;0m"
+    RUN_JSCS=0
+fi
+
+# Run JSCS
+if [ $RUN_JSCS -ne 0 ]; then
+    echo -e "\033[0;34mChecking JS style...\033[0;0m"
+    OUT=`$JSCS_PATH -r text $TMPDIR`
+    CODE=$?
+    # Erase last output line
+    # echo -ne '\r\033[K'
+    if [ $CODE -ne 0 ]; then
+        # Remove temp dir from output and color the filename
+        OUT=`echo "$OUT" | sed "s,$TMPDIR/\([^ ]*\),\`echo -e \"\033[0;34m\1\033[0m\"\`,"`
+        TOTAL_ERRORS=`echo -e "$OUT" | sed 's/[^0-9]//g' | tail -1`
+        # echo output minus last line
+        echo "$OUT" | sed '$ d'
+        if [ $TOTAL_ERRORS -ne 1 ]; then
+          PLURAL_SUFFIX="s"
+        fi
+        echo -e "\033[0;31m$TOTAL_ERRORS code style error$PLURAL_SUFFIX found.\033[0;0m"
+        echo "Please fix and re-commit."
+        echo -e "Need to commit right away? commit with the \033[0;34m-n\033[0m flag"
+        rm -Rf $TMPDIR $TMPFILE
+        exit $CODE
+    else
+        echo -e "\033[0;32mNo JS code style errors found.\033[0;0m"
+    fi
+fi
+
+# Clean up
+rm -Rf $TMPDIR $TMPFILE

--- a/scripts/jscs-pre-commit
+++ b/scripts/jscs-pre-commit
@@ -1,61 +1,16 @@
-#!/bin/bash
+#!/bin/bash +ex
 
-# Adapted from
-# https://raw.githubusercontent.com/flightjs/flight/master/jscs-pre-commit
+# Runs JSCS style checker using definitions in `.jscsrc`
+#
 
-export JSCS_PATH='node_modules/.bin/jscs'
+# pre-commit.sh
+git stash -q --keep-index
 
-# Extract staged files to a temp directory
-TMPDIR=
-TMPFILE=
-if [ "$IS_LINUX" == "true" ]; then
-    TMPFILE=`mktemp jscs_tmp_XXXXXX`
-    TMPDIR=`mktemp -d jscs_tmp_XXXXXX`
-else
-    TMPFILE=`mktemp -t tmp/jscs_tmp_XXXXXX`
-    TMPDIR=`mktemp -t tmp/jscs_tmp -d`
-fi
-git diff --cached --name-only --diff-filter=ACMR | xargs git checkout-index --prefix=$TMPDIR/ --
+# Test prospective commit
+git diff-index --cached HEAD --name-only --diff-filter ACMR | egrep '.js$' | xargs $(npm bin)/jscs
+RESULT=$?
 
-# Check JavaScript code style
-RUN_JSCS=1
-TOTAL_ERRORS=0
-PLURAL_SUFFIX=
+git stash pop -q
 
-JSFILES=$(git diff-index --name-status --cached HEAD | grep -v ^D | egrep '.js$' | cut -c3-)
-if [ -z "$JSFILES" ]; then
-    # No JavaScript file changed for this commit
-    RUN_JSCS=0
-elif [ -z "$JSCS_PATH" ]; then
-    echo -e "\033[0;31mIf you \033[1;34mnpm install jscs -g\033[0;31m I'll check your JS style\033[0;0m"
-    RUN_JSCS=0
-fi
-
-# Run JSCS
-if [ $RUN_JSCS -ne 0 ]; then
-    echo -e "\033[0;34mChecking JS style...\033[0;0m"
-    OUT=`$JSCS_PATH -r text $TMPDIR`
-    CODE=$?
-    # Erase last output line
-    # echo -ne '\r\033[K'
-    if [ $CODE -ne 0 ]; then
-        # Remove temp dir from output and color the filename
-        OUT=`echo "$OUT" | sed "s,$TMPDIR/\([^ ]*\),\`echo -e \"\033[0;34m\1\033[0m\"\`,"`
-        TOTAL_ERRORS=`echo -e "$OUT" | sed 's/[^0-9]//g' | tail -1`
-        # echo output minus last line
-        echo "$OUT" | sed '$ d'
-        if [ $TOTAL_ERRORS -ne 1 ]; then
-          PLURAL_SUFFIX="s"
-        fi
-        echo -e "\033[0;31m$TOTAL_ERRORS code style error$PLURAL_SUFFIX found.\033[0;0m"
-        echo "Please fix and re-commit."
-        echo -e "Need to commit right away? commit with the \033[0;34m-n\033[0m flag"
-        rm -Rf $TMPDIR $TMPFILE
-        exit $CODE
-    else
-        echo -e "\033[0;32mNo JS code style errors found.\033[0;0m"
-    fi
-fi
-
-# Clean up
-rm -Rf $TMPDIR $TMPFILE
+[ $RESULT -ne 0 ] && exit 1
+exit 0


### PR DESCRIPTION
@cjohansen @mantoni you should test this locally before merging.

1. `npm install`
2. Modify a file, making an invalid change that JSCS looks for
3. Modify another file, making an invalid change that JSCS looks for
3. Stage the changes from one of the files
4. `git commit`

If all works as intended, then JSCS will complain about just the staged changes, ignoring the other file