### PR TITLE
Update jscs dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
   },
   "devDependencies": {
     "buster": "0.7.18",
-    "jscs": "1.11.3",
-    "buster-istanbul": "0.1.13"
+    "buster-istanbul": "0.1.13",
+    "jscs": "1.13.1"
   },
   "files": [
     "lib",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "ci-test": "./scripts/ci-test.sh",
     "test": "npm run lint && ./scripts/ci-test.sh",
-    "lint": "jscs .",
+    "lint": "$(npm bin)/jscs .",
     "prepublish": "./build"
   },
   "dependencies": {


### PR DESCRIPTION
* Fix mistake where `npm run lint` would use global `jscs` binary
* Update JSCS to 1.13.1 