### PR TITLE
Quote yield as it's a reserved keyword in strict mode.

### DIFF
--- a/lib/sinon/call.js
+++ b/lib/sinon/call.js
@@ -118,7 +118,7 @@
                 this.args[pos].apply(thisValue, args);
             },
 
-            yield: function () {
+            "yield": function () {
                 this.yieldOn.apply(this, [null].concat(slice.call(arguments, 0)));
             },
 


### PR DESCRIPTION
Hey,

Android 4.0 fails when using `yield` in strict mode.
This resolves the issue.