### PR TITLE
Fix intermittent build failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - "0.6"
   - "0.8"
   - "0.10"
   - "0.12"
@@ -9,9 +8,15 @@ sudo: false
 
 before_install:
   - npm config set strict-ssl false
-  # use a more modern npm than ships with 0.6 and 0.8
-  - 'if [ "x$TRAVIS_NODE_VERSION" = "x0.6" ]; then npm install -g npm@1.3; fi'
+  # use a more modern npm than ships with 0.8
   - 'if [ "x$TRAVIS_NODE_VERSION" = "x0.8" ]; then npm install -g npm@1.4; fi'
+  # Workaround for intermittent build failures
+  # install buster separately from `npm install`, as it uses the C compiler, which might cause the
+  #   npm ERR! cb() never called!
+  # errror to appear, causing the builds to fail
+  #
+  # See this discussion: https://github.com/npm/npm/issues/7014
+  - npm install buster@0.7.18
 
 before_script:
   - rvm install 2.2.0


### PR DESCRIPTION
Fix the issue of intermittent CI build failures where
`npm install` exits with the following error

```
npm ERR! cb() never called!
```

It seems to be caused by a race condition when npm is installing
things in parallel that happens to use the C compiler.

Temporary solution found via https://github.com/npm/npm/issues/7014.

Hopefully, npm@3 won't have this issue.