### PR TITLE
Pass options to fakeserver create 784

### DIFF
--- a/lib/sinon/util/fake_server.js
+++ b/lib/sinon/util/fake_server.js
@@ -105,7 +105,7 @@ if (typeof sinon == "undefined") {
                 setting;
                 config = config || {};
                 for (setting in config) {
-                    if (whitelist[setting] && config.hasOwnProperty(setting)) {
+                    if (whitelist.hasOwnProperty(setting) && config.hasOwnProperty(setting)) {
                         this[setting] = config[setting];
                     }
                 }

--- a/lib/sinon/util/fake_server.js
+++ b/lib/sinon/util/fake_server.js
@@ -105,7 +105,7 @@ if (typeof sinon == "undefined") {
                 setting;
                 config = config || {};
                 for (setting in config) {
-                    if (whitelist[setting]) {
+                    if (whitelist[setting] && config.hasOwnProperty(setting)) {
                         this[setting] = config[setting];
                     }
                 }

--- a/lib/sinon/util/fake_server.js
+++ b/lib/sinon/util/fake_server.js
@@ -79,8 +79,9 @@ if (typeof sinon == "undefined") {
 
     function makeApi(sinon) {
         sinon.fakeServer = {
-            create: function () {
+            create: function (config) {
                 var server = create(this);
+                server.configure(config);
                 if (!sinon.xhr.supportsCORS) {
                     this.xhr = sinon.useFakeXDomainRequest();
                 } else {
@@ -94,7 +95,21 @@ if (typeof sinon == "undefined") {
 
                 return server;
             },
-
+            configure: function (config) {
+                var whitelist = {
+                    "autoRespond": true,
+                    "autoRespondAfter": true,
+                    "respondImmediately": true,
+                    "fakeHTTPMethods": true
+                },
+                setting;
+                config = config || {};
+                for (setting in config) {
+                    if (whitelist[setting]) {
+                        this[setting] = config[setting];
+                    }
+                }
+            },
             addRequest: function addRequest(xhrObj) {
                 var server = this;
                 push.call(this.requests, xhrObj);

--- a/test/fake-server-test.js
+++ b/test/fake-server-test.js
@@ -1,0 +1,31 @@
+(function (root) {
+    "use strict";
+
+    var buster = root.buster || require("buster"),
+        sinon = root.sinon || require("../lib/sinon"),
+        assert = buster.assert,
+        refute = buster.refute;
+
+    buster.testCase("sinon.fakeServer", {
+        ".create": {
+            "allows valid init settings" : function () {
+                var server = sinon.fakeServer.create({
+                    autoRespond: true
+                });
+                assert(
+                    server.autoRespond,
+                    "serve.create should accept whitelisted settings"
+                );
+            },
+            "does not assign invalid settings": function () {
+                var server = sinon.fakeServer.create({
+                    foo: true
+                });
+                refute(
+                    server.foo,
+                    "server should not accept non-whitelisted settings"
+                );
+            }
+        }
+    });
+}(this));

--- a/test/fake-server-test.js
+++ b/test/fake-server-test.js
@@ -8,22 +8,49 @@
 
     buster.testCase("sinon.fakeServer", {
         ".create": {
-            "allows valid init settings" : function () {
+            "allows 'autoRespond' init settings" : function () {
                 var server = sinon.fakeServer.create({
                     autoRespond: true
                 });
                 assert(
                     server.autoRespond,
-                    "serve.create should accept whitelisted settings"
+                    "fakeServer.create should accept 'autoRespond' setting"
                 );
             },
-            "does not assign invalid settings": function () {
+            "allows 'autoRespondAfter' init settings" : function () {
+                var server = sinon.fakeServer.create({
+                    autoRespond: true
+                });
+                assert(
+                    server.autoRespond,
+                    "fakeServer.create should accept 'autoRespondAfter' setting"
+                );
+            },
+            "allows 'respondImmediately' init settings" : function () {
+                var server = sinon.fakeServer.create({
+                    autoRespond: true
+                });
+                assert(
+                    server.autoRespond,
+                    "fakeServer.create should accept 'respondImmediately' setting"
+                );
+            },
+            "allows 'fakeHTTPMethods' init settings" : function () {
+                var server = sinon.fakeServer.create({
+                    autoRespond: true
+                });
+                assert(
+                    server.autoRespond,
+                    "fakeServer.create should accept 'fakeHTTPMethods' setting"
+                );
+            },
+            "does not assign non-whitelisted settings": function () {
                 var server = sinon.fakeServer.create({
                     foo: true
                 });
                 refute(
                     server.foo,
-                    "server should not accept non-whitelisted settings"
+                    "fakeServer.create should not accept 'foo' settings"
                 );
             }
         }


### PR DESCRIPTION
This PR fixes the issues from my previous PR #785.
This allows fakeServer to be created with a whitelisted set of settings and adds a configure method which allows the server to be configured from an object literal.

So sorry for the repeated PR's. Realized that in order to safeguard completely against `Object.prototype` extensions I need to check `hasOwnProperty` on both the whitelist and settings.