### PR TITLE
fakeServer.create accepts configuration settings

### DIFF
--- a/lib/sinon/util/fake_server.js
+++ b/lib/sinon/util/fake_server.js
@@ -79,8 +79,9 @@ if (typeof sinon == "undefined") {
 
     function makeApi(sinon) {
         sinon.fakeServer = {
-            create: function () {
+            create: function (config) {
                 var server = create(this);
+                server.configure(config);
                 if (!sinon.xhr.supportsCORS) {
                     this.xhr = sinon.useFakeXDomainRequest();
                 } else {
@@ -94,7 +95,21 @@ if (typeof sinon == "undefined") {
 
                 return server;
             },
-
+            configure: function (config) {
+                var whitelist = {
+                    "autoRespond": true,
+                    "autoRespondAfter": true,
+                    "respondImmediately": true,
+                    "fakeHTTPMethods": true
+                },
+                setting;
+                config = config || {};
+                for (setting in config) {
+                    if (whitelist.hasOwnProperty(setting) && config.hasOwnProperty(setting)) {
+                        this[setting] = config[setting];
+                    }
+                }
+            },
             addRequest: function addRequest(xhrObj) {
                 var server = this;
                 push.call(this.requests, xhrObj);

--- a/test/fake-server-test.js
+++ b/test/fake-server-test.js
@@ -1,0 +1,58 @@
+(function (root) {
+    "use strict";
+
+    var buster = root.buster || require("buster"),
+        sinon = root.sinon || require("../lib/sinon"),
+        assert = buster.assert,
+        refute = buster.refute;
+
+    buster.testCase("sinon.fakeServer", {
+        ".create": {
+            "allows the 'autoRespond' setting" : function () {
+                var server = sinon.fakeServer.create({
+                    autoRespond: true
+                });
+                assert(
+                    server.autoRespond,
+                    "fakeServer.create should accept 'autoRespond' setting"
+                );
+            },
+            "allows the 'autoRespondAfter' setting" : function () {
+                var server = sinon.fakeServer.create({
+                    autoRespond: true
+                });
+                assert(
+                    server.autoRespond,
+                    "fakeServer.create should accept 'autoRespondAfter' setting"
+                );
+            },
+            "allows the 'respondImmediately' setting" : function () {
+                var server = sinon.fakeServer.create({
+                    autoRespond: true
+                });
+                assert(
+                    server.autoRespond,
+                    "fakeServer.create should accept 'respondImmediately' setting"
+                );
+            },
+            "allows the 'fakeHTTPMethods' setting" : function () {
+                var server = sinon.fakeServer.create({
+                    autoRespond: true
+                });
+                assert(
+                    server.autoRespond,
+                    "fakeServer.create should accept 'fakeHTTPMethods' setting"
+                );
+            },
+            "does not assign a non-whitelisted setting": function () {
+                var server = sinon.fakeServer.create({
+                    foo: true
+                });
+                refute(
+                    server.foo,
+                    "fakeServer.create should not accept 'foo' settings"
+                );
+            }
+        }
+    });
+}(this));


### PR DESCRIPTION
This allows fakeServer to be created with a whitelisted set of settings and adds a configure method which allows the server to be configured from an object literal. Fixes #784

All squished into one nice commit. 