### PR TITLE
Fire onreadystatechange with event argument

### DIFF
--- a/lib/sinon/util/fake_xml_http_request.js
+++ b/lib/sinon/util/fake_xml_http_request.js
@@ -381,9 +381,11 @@
             readyStateChange: function readyStateChange(state) {
                 this.readyState = state;
 
+                var readyStateChangeEvent = new sinon.Event("readystatechange", false, false, this);
+
                 if (typeof this.onreadystatechange === "function") {
                     try {
-                        this.onreadystatechange();
+                        this.onreadystatechange(readyStateChangeEvent);
                     } catch (e) {
                         sinon.logError("Fake XHR onreadystatechange handler", e);
                     }
@@ -401,7 +403,7 @@
                         break;
                 }
 
-                this.dispatchEvent(new sinon.Event("readystatechange"));
+                this.dispatchEvent(readyStateChangeEvent);
             },
 
             setRequestHeader: function setRequestHeader(header, value) {

--- a/test/util/fake-xml-http-request-test.js
+++ b/test/util/fake-xml-http-request-test.js
@@ -393,16 +393,19 @@
             },
 
             "dispatches onreadystatechange": function () {
-                var state;
+                var event, state;
                 this.xhr.open("POST", "/", false);
 
-                this.xhr.onreadystatechange = function () {
+                this.xhr.onreadystatechange = function (e) {
+                    event = e;
                     state = this.readyState;
                 };
 
                 this.xhr.send("Data");
 
                 assert.equals(state, sinon.FakeXMLHttpRequest.OPENED);
+                assert.equals(event.type, "readystatechange");
+                assert.defined(event.target);
             },
 
             "dispatches event using DOM Event interface": function () {
@@ -414,6 +417,7 @@
 
                 assert(listener.calledOnce);
                 assert.equals(listener.args[0][0].type, "readystatechange");
+                assert.defined(listener.args[0][0].target);
             },
 
             "dispatches onSend callback if set": function () {


### PR DESCRIPTION
According to the [W3C spec for XMLHTTPRequest][1], the XHR object
should support an 'onreadystatechange' callback which is defined
as a standard [event handler][2] in accordance with the HTML5 spec.

This means that it should be triggered with a single Event argument,
similarly to how event callbacks registered via 'addEventListener'
function (see [event handler algorithm section of spec][3]). While
it's not often the case that code samples or even most code out in
the wild relies on this Event argument (usually the callback will
just take advantage of the 'this' object or reference the XHR object
via a closure variable), it should still be supported to have parity
with the existing browser implementation it stubs.

You can verify that this is the browser behavior using [this simple fiddle.][4]

[1]: http://www.w3.org/TR/XMLHttpRequest/#event-handlers
[2]: http://www.w3.org/html/wg/drafts/html/master/webappapis.html#event-handlers
[3]: http://www.w3.org/html/wg/drafts/html/master/webappapis.html#the-event-handler-processing-algorithm
[4]: https://jsfiddle.net/diurnalist/4su2ka23/