### PR TITLE
Reapply: Returns supersedes previous throws

### DIFF
--- a/lib/sinon/behavior.js
+++ b/lib/sinon/behavior.js
@@ -302,6 +302,7 @@
             returns: function returns(value) {
                 this.returnValue = value;
                 this.returnValueDefined = true;
+                this.exception = undefined;
 
                 return this;
             },

--- a/test/stub-test.js
+++ b/test/stub-test.js
@@ -66,6 +66,15 @@
                 var stub = sinon.stub.create();
 
                 refute.defined(stub());
+            },
+
+            "supersedes previous throws": function () {
+                var stub = sinon.stub.create();
+                stub.throws().returns(1);
+
+                refute.exception(function () {
+                    stub();
+                });
             }
         },
 


### PR DESCRIPTION
Allows overriding a `throws()` call with `returns()`. Currently `stub.throws().returns()` will throw instead of returning.

original: https://github.com/cjohansen/Sinon.JS/pull/644
ref: https://github.com/cjohansen/Sinon.JS/issues/643