### PR TITLE
Set ESLint `one-var` to error (2)

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -149,7 +149,12 @@
         "newline-after-var": 0,
         "object-curly-spacing": [0, "never"],
         "object-shorthand": 0,
-        "one-var": 0,
+        "one-var": [2, {
+             // Exactly one declaration for uninitialized variables per function (var) or block (let or const)
+            "uninitialized": "always",
+             // Exactly one declarator per initialized variable declaration per function (var) or block (let or const)
+            "initialized": "never"
+        }],
         "operator-assignment": [0, "always"],
         "operator-linebreak": 0,
         "padded-blocks": 0,

--- a/lib/sinon/assert.js
+++ b/lib/sinon/assert.js
@@ -97,7 +97,8 @@
 
             callOrder: function assertCallOrder() {
                 verifyIsStub.apply(null, arguments);
-                var expected = "", actual = "";
+                var expected = "";
+                var actual = "";
 
                 if (!sinon.calledInOrder(arguments)) {
                     try {

--- a/lib/sinon/extend.js
+++ b/lib/sinon/extend.js
@@ -59,8 +59,8 @@
          * Returns the extended target
          */
         function extend(target /*, sources */) {
-            var sources = Array.prototype.slice.call(arguments, 1),
-                source, i, prop;
+            var sources = Array.prototype.slice.call(arguments, 1);
+            var source, i, prop;
 
             for (i = 0; i < sources.length; i++) {
                 source = sources[i];

--- a/lib/sinon/format.js
+++ b/lib/sinon/format.js
@@ -45,8 +45,8 @@
             return util ? format : valueFormatter;
         }
 
-        var isNode = typeof module !== "undefined" && module.exports && typeof require === "function",
-            formatter;
+        var isNode = typeof module !== "undefined" && module.exports && typeof require === "function";
+        var formatter;
 
         if (isNode) {
             try {

--- a/lib/sinon/mock.js
+++ b/lib/sinon/mock.js
@@ -110,7 +110,8 @@
 
             verify: function verify() {
                 var expectations = this.expectations || {};
-                var messages = [], met = [];
+                var messages = [];
+                var met = [];
 
                 each(this.proxies, function (proxy) {
                     each(expectations[proxy], function (expectation) {
@@ -134,10 +135,10 @@
             },
 
             invokeMethod: function invokeMethod(method, thisValue, args) {
-                var expectations = this.expectations && this.expectations[method] ? this.expectations[method] : [],
-                    expectationsWithMatchingArgs = [],
-                    currentArgs = args || [],
-                    i;
+                var expectations = this.expectations && this.expectations[method] ? this.expectations[method] : [];
+                var expectationsWithMatchingArgs = [];
+                var currentArgs = args || [];
+                var i, available;
 
                 for (i = 0; i < expectations.length; i += 1) {
                     var expectedArgs = expectations[i].expectedArguments || [];
@@ -153,7 +154,8 @@
                     }
                 }
 
-                var messages = [], available, exhausted = 0;
+                var messages = [];
+                var exhausted = 0;
 
                 for (i = 0; i < expectationsWithMatchingArgs.length; i += 1) {
                     if (expectationsWithMatchingArgs[i].allowsCall(thisValue, args)) {

--- a/lib/sinon/sandbox.js
+++ b/lib/sinon/sandbox.js
@@ -115,7 +115,9 @@
                 sandbox.args = sandbox.args || [];
                 sandbox.injectedKeys = [];
                 sandbox.injectInto = config.injectInto;
-                var prop, value, exposed = sandbox.inject({});
+                var prop,
+                    value;
+                var exposed = sandbox.inject({});
 
                 if (config.properties) {
                     for (var i = 0, l = config.properties.length; i < l; i++) {

--- a/lib/sinon/stub.js
+++ b/lib/sinon/stub.js
@@ -21,7 +21,8 @@
                 throw new TypeError("Custom stub should be a function or a property descriptor");
             }
 
-            var wrapper;
+            var wrapper,
+                prop;
 
             if (func) {
                 if (typeof func === "function") {
@@ -48,7 +49,7 @@
             }
 
             if (typeof property === "undefined" && typeof object === "object") {
-                for (var prop in object) {
+                for (prop in object) {
                     if (typeof sinon.getPropertyDescriptor(object, prop).value === "function") {
                         stub(object, prop);
                     }

--- a/lib/sinon/test_case.js
+++ b/lib/sinon/test_case.js
@@ -47,9 +47,12 @@
 
             prefix = prefix || "test";
             var rPrefix = new RegExp("^" + prefix);
-            var methods = {}, testName, property, method;
+            var methods = {};
             var setUp = tests.setUp;
             var tearDown = tests.tearDown;
+            var testName,
+                property,
+                method;
 
             for (testName in tests) {
                 if (tests.hasOwnProperty(testName) && !/^(setUp|tearDown)$/.test(testName)) {

--- a/lib/sinon/util/core.js
+++ b/lib/sinon/util/core.js
@@ -92,16 +92,15 @@
                 }
             }
 
-            var error, wrappedMethod;
+            var error, wrappedMethod, i;
 
             // IE 8 does not support hasOwnProperty on the window object and Firefox has a problem
             // when using hasOwn.call on objects from other frames.
             var owned = object.hasOwnProperty ? object.hasOwnProperty(property) : hasOwn.call(object, property);
 
             if (hasES5Support) {
-                var methodDesc = (typeof method === "function") ? {value: method} : method,
-                    wrappedMethodDesc = sinon.getPropertyDescriptor(object, property),
-                    i;
+                var methodDesc = (typeof method === "function") ? {value: method} : method;
+                var wrappedMethodDesc = sinon.getPropertyDescriptor(object, property);
 
                 if (!wrappedMethodDesc) {
                     error = new TypeError("Attempted to wrap " + (typeof wrappedMethod) + " property " +
@@ -212,7 +211,9 @@
                 return a.valueOf() === b.valueOf();
             }
 
-            var prop, aLength = 0, bLength = 0;
+            var prop;
+            var aLength = 0;
+            var bLength = 0;
 
             if (aString === "[object Array]" && a.length !== b.length) {
                 return false;
@@ -258,7 +259,9 @@
 
         sinon.functionToString = function toString() {
             if (this.getCall && this.callCount) {
-                var thisValue, prop, i = this.callCount;
+                var thisValue,
+                    prop;
+                var i = this.callCount;
 
                 while (i--) {
                     thisValue = this.getCall(i).thisValue;
@@ -291,7 +294,9 @@
         };
 
         sinon.getPropertyDescriptor = function getPropertyDescriptor(object, property) {
-            var proto = object, descriptor;
+            var proto = object;
+            var descriptor;
+
             while (proto && !(descriptor = Object.getOwnPropertyDescriptor(proto, property))) {
                 proto = Object.getPrototypeOf(proto);
             }

--- a/lib/sinon/util/fake_server.js
+++ b/lib/sinon/util/fake_server.js
@@ -91,8 +91,9 @@
                     "autoRespondAfter": true,
                     "respondImmediately": true,
                     "fakeHTTPMethods": true
-                },
-                setting;
+                };
+                var setting;
+
                 config = config || {};
                 for (setting in config) {
                     if (whitelist.hasOwnProperty(setting) && config.hasOwnProperty(setting)) {

--- a/lib/sinon/util/fake_timers.js
+++ b/lib/sinon/util/fake_timers.js
@@ -23,7 +23,8 @@
         var llx = typeof lolex !== "undefined" ? lolex : lol;
 
         s.useFakeTimers = function () {
-            var now, methods = Array.prototype.slice.call(arguments);
+            var now;
+            var methods = Array.prototype.slice.call(arguments);
 
             if (typeof methods[0] === "string") {
                 now = 0;

--- a/test/assert-test.js
+++ b/test/assert-test.js
@@ -1,10 +1,10 @@
 (function (root) {
     "use strict";
 
-    var buster = root.buster || require("buster"),
-        sinon = root.sinon || require("../lib/sinon"),
-        assert = buster.assert,
-        refute = buster.refute;
+    var buster = root.buster || require("buster");
+    var sinon = root.sinon || require("../lib/sinon");
+    var assert = buster.assert;
+    var refute = buster.refute;
 
     buster.testCase("sinon.assert", {
         setUp: function () {

--- a/test/call-test.js
+++ b/test/call-test.js
@@ -1,10 +1,10 @@
 (function (root) {
     "use strict";
 
-    var buster = root.buster || require("buster"),
-        sinon = root.sinon || require("../lib/sinon"),
-        assert = buster.assert,
-        refute = buster.refute;
+    var buster = root.buster || require("buster");
+    var sinon = root.sinon || require("../lib/sinon");
+    var assert = buster.assert;
+    var refute = buster.refute;
 
     function spyCallSetUp() {
         this.thisValue = {};

--- a/test/collection-test.js
+++ b/test/collection-test.js
@@ -1,9 +1,9 @@
 (function (root) {
     "use strict";
 
-    var buster = root.buster || require("buster"),
-        sinon = root.sinon || require("../lib/sinon"),
-        assert = buster.assert;
+    var buster = root.buster || require("buster");
+    var sinon = root.sinon || require("../lib/sinon");
+    var assert = buster.assert;
 
     buster.testCase("sinon.collection", {
         "creates fake collection": function () {

--- a/test/extend-test.js
+++ b/test/extend-test.js
@@ -1,9 +1,9 @@
 (function (root) {
     "use strict";
 
-    var buster = root.buster || require("buster"),
-        sinon = root.sinon || require("../lib/sinon"),
-        assert = buster.assert;
+    var buster = root.buster || require("buster");
+    var sinon = root.sinon || require("../lib/sinon");
+    var assert = buster.assert;
 
     buster.testCase("sinon.extend", {
         "should return unaltered target when only one argument": function () {
@@ -26,16 +26,16 @@
 
         "should copy toString method into target": function () {
             var target = {
-                    hello: "world",
-                    toString: function () {
-                        return "hello world";
-                    }
-                },
-                source = {
-                    toString: function () {
-                        return "hello source";
-                    }
-                };
+                hello: "world",
+                toString: function () {
+                    return "hello world";
+                }
+            };
+            var source = {
+                toString: function () {
+                    return "hello source";
+                }
+            };
 
             sinon.extend(target, source);
 
@@ -43,12 +43,12 @@
         },
 
         "must copy the last occuring property into the target": function () {
-            var target = { a: 0, b: 0, c: 0, d: 0 },
-                source1 = { a: 1, b: 1, c: 1 },
-                source2 = { a: 2, b: 2 },
-                soruce3 = { a: 3 };
+            var target = { a: 0, b: 0, c: 0, d: 0 };
+            var source1 = { a: 1, b: 1, c: 1 };
+            var source2 = { a: 2, b: 2 };
+            var source3 = { a: 3 };
 
-            sinon.extend(target, source1, source2, soruce3);
+            sinon.extend(target, source1, source2, source3);
 
             assert.equals(target.a, 3);
             assert.equals(target.b, 2);

--- a/test/format-test.js
+++ b/test/format-test.js
@@ -1,9 +1,9 @@
 (function (root) {
     "use strict";
 
-    var buster = root.buster || require("buster"),
-        sinon = root.sinon || require("../lib/sinon"),
-        assert = buster.assert;
+    var buster = root.buster || require("buster");
+    var sinon = root.sinon || require("../lib/sinon");
+    var assert = buster.assert;
 
     buster.testCase("sinon.format", {
         "formats with formatio by default": function () {

--- a/test/hello-world-test.js
+++ b/test/hello-world-test.js
@@ -1,8 +1,10 @@
+// this is a very simple testcase primarily used for debugging
+// issues with the AMD setup
 (function (root) {
     "use strict";
 
-    var buster = root.buster || require("buster"),
-        assert = buster.assert;
+    var buster = root.buster || require("buster");
+    var assert = buster.assert;
 
     buster.testCase("hello world", {
         "hello world test": function () {

--- a/test/issues/issues-test.js
+++ b/test/issues/issues-test.js
@@ -1,10 +1,10 @@
 (function (root) {
     "use strict";
 
-    var buster = root.buster || require("buster"),
-        sinon = root.sinon || require("../../lib/sinon"),
-        assert = buster.assert,
-        refute = buster.refute;
+    var buster = root.buster || require("buster");
+    var sinon = root.sinon || require("../../lib/sinon");
+    var assert = buster.assert;
+    var refute = buster.refute;
 
     buster.testCase("issues", {
         setUp: function () {

--- a/test/log-error-test.js
+++ b/test/log-error-test.js
@@ -1,9 +1,9 @@
 (function (root) {
     "use strict";
 
-    var buster = root.buster || require("buster"),
-        sinon = root.sinon || require("../lib/sinon"),
-        assert = buster.assert;
+    var buster = root.buster || require("buster");
+    var sinon = root.sinon || require("../lib/sinon");
+    var assert = buster.assert;
 
     buster.testCase("sinon.log", {
         "is a function": function () {
@@ -27,10 +27,10 @@
         },
 
         "calls sinon.log with a String": function () {
-            var spy = this.sandbox.spy(sinon, "log"),
-                name = "Quisque consequat, elit id suscipit.",
-                message = "Pellentesque gravida orci in tellus tristique, ac commodo nibh congue.",
-                error = new Error();
+            var spy = this.sandbox.spy(sinon, "log");
+            var name = "Quisque consequat, elit id suscipit.";
+            var message = "Pellentesque gravida orci in tellus tristique, ac commodo nibh congue.";
+            var error = new Error();
 
             error.name = name;
             error.message = message;

--- a/test/match-test.js
+++ b/test/match-test.js
@@ -1,9 +1,9 @@
 (function (root) {
     "use strict";
 
-    var buster = root.buster || require("buster"),
-        sinon = root.sinon || require("../lib/sinon"),
-        assert = buster.assert;
+    var buster = root.buster || require("buster");
+    var sinon = root.sinon || require("../lib/sinon");
+    var assert = buster.assert;
 
     function propertyMatcherTests(matcher) {
         return {

--- a/test/mock-test.js
+++ b/test/mock-test.js
@@ -1,10 +1,10 @@
 (function (root) {
     "use strict";
 
-    var buster = root.buster || require("buster"),
-        sinon = root.sinon || require("../lib/sinon"),
-        assert = buster.assert,
-        refute = buster.refute;
+    var buster = root.buster || require("buster");
+    var sinon = root.sinon || require("../lib/sinon");
+    var assert = buster.assert;
+    var refute = buster.refute;
 
     buster.testCase("sinon.mock", {
         ".create": {

--- a/test/sandbox-test.js
+++ b/test/sandbox-test.js
@@ -1,11 +1,11 @@
 (function (root) {
     "use strict";
 
-    var buster = root.buster || require("buster"),
-        sinon = root.sinon || require("../lib/sinon"),
-        assert = buster.assert,
-        refute = buster.refute,
-        samsam = root.samsam || require("samsam");
+    var buster = root.buster || require("buster");
+    var sinon = root.sinon || require("../lib/sinon");
+    var assert = buster.assert;
+    var refute = buster.refute;
+    var samsam = root.samsam || require("samsam");
 
     var supportsAjax = typeof XMLHttpRequest !== "undefined" || typeof ActiveXObject !== "undefined";
     var globalXHR = root.XMLHttpRequest;
@@ -315,11 +315,11 @@
             },
 
             "does not inject properties if they are already present": function () {
-                var server = function () {},
-                    clock = {},
-                    spy = false,
-                    object = { server: server, clock: clock, spy: spy},
-                    sandbox = sinon.sandbox.create(sinon.getConfig({
+                var server = function () {};
+                var clock = {};
+                var spy = false;
+                var object = { server: server, clock: clock, spy: spy};
+                var sandbox = sinon.sandbox.create(sinon.getConfig({
                         properties: ["server", "clock", "spy"],
                         injectInto: object
                     }));

--- a/test/sinon-test.js
+++ b/test/sinon-test.js
@@ -1,10 +1,10 @@
 (function (root) {
     "use strict";
 
-    var buster = root.buster || require("buster"),
-        sinon = root.sinon || require("../lib/sinon"),
-        assert = buster.assert,
-        refute = buster.refute;
+    var buster = root.buster || require("buster");
+    var sinon = root.sinon || require("../lib/sinon");
+    var assert = buster.assert;
+    var refute = buster.refute;
 
     buster.testCase("sinon", {
         ".wrapMethod": {
@@ -550,7 +550,9 @@
             },
 
             "guesses name from any call where property can be located": function () {
-                var obj = {}, otherObj = { id: 42 };
+                var obj = {};
+                var otherObj = { id: 42 };
+
                 obj.doStuff = sinon.spy();
                 obj.doStuff.call({});
                 obj.doStuff();

--- a/test/spy-test.js
+++ b/test/spy-test.js
@@ -1,10 +1,10 @@
 (function (root) {
     "use strict";
 
-    var buster = root.buster || require("buster"),
-        sinon = root.sinon || require("../lib/sinon"),
-        assert = buster.assert,
-        refute = buster.refute;
+    var buster = root.buster || require("buster");
+    var sinon = root.sinon || require("../lib/sinon");
+    var assert = buster.assert;
+    var refute = buster.refute;
 
     function spyCalledTests(method) {
         return {
@@ -339,8 +339,8 @@
             },
 
             "retains function length 12": function () {
-                var func12Args = function (a, b, c, d, e, f, g, h, i, j, k, l) {}, // eslint-disable-line no-unused-vars
-                    spy = sinon.spy.create(func12Args);
+                var func12Args = function (a, b, c, d, e, f, g, h, i, j, k, l) {}; // eslint-disable-line no-unused-vars
+                var spy = sinon.spy.create(func12Args);
 
                 assert.equals(spy.length, 12);
             }

--- a/test/stub-test.js
+++ b/test/stub-test.js
@@ -1,11 +1,11 @@
 (function (root) {
     "use strict";
 
-    var buster = root.buster || require("buster"),
-        sinon = root.sinon || require("../lib/sinon"),
-        assert = buster.assert,
-        refute = buster.refute,
-        fail = buster.referee.fail;
+    var buster = root.buster || require("buster");
+    var sinon = root.sinon || require("../lib/sinon");
+    var assert = buster.assert;
+    var refute = buster.refute;
+    var fail = buster.referee.fail;
 
     buster.testCase("sinon.stub", {
         "is spy": function () {

--- a/test/test-case-test.js
+++ b/test/test-case-test.js
@@ -1,10 +1,10 @@
 (function (root) {
     "use strict";
 
-    var buster = root.buster || require("buster"),
-        sinon = root.sinon || require("../lib/sinon"),
-        assert = buster.assert,
-        refute = buster.refute;
+    var buster = root.buster || require("buster");
+    var sinon = root.sinon || require("../lib/sinon");
+    var assert = buster.assert;
+    var refute = buster.refute;
 
     buster.testCase("sinon.testCase", {
         "throws without argument": function () {

--- a/test/test-test.js
+++ b/test/test-test.js
@@ -1,10 +1,10 @@
 (function (root) {
     "use strict";
 
-    var buster = root.buster || require("buster"),
-        sinon = root.sinon || require("../lib/sinon"),
-        assert = buster.assert,
-        refute = buster.refute;
+    var buster = root.buster || require("buster");
+    var sinon = root.sinon || require("../lib/sinon");
+    var assert = buster.assert;
+    var refute = buster.refute;
 
     buster.testCase("sinon.test", {
         setUp: function () {

--- a/test/times-in-words-test.js
+++ b/test/times-in-words-test.js
@@ -1,9 +1,9 @@
 (function (root) {
     "use strict";
 
-    var buster = root.buster || require("buster"),
-        sinon = root.sinon || require("../lib/sinon"),
-        assert = buster.assert;
+    var buster = root.buster || require("buster");
+    var sinon = root.sinon || require("../lib/sinon");
+    var assert = buster.assert;
 
     buster.testCase("sinon.timesInWords", {
         "should return \"once\" for input of 1": function () {
@@ -31,8 +31,8 @@
         },
 
         "should return \"0 times\" for falsy input": function () {
-            var falsies = [0, NaN, null, false, undefined, ""],
-                result, i;
+            var falsies = [0, NaN, null, false, undefined, ""];
+            var result, i;
 
             for (i = 0; i < falsies.length; i++) {
                 result = sinon.timesInWords(falsies[i]);

--- a/test/typeOf-test.js
+++ b/test/typeOf-test.js
@@ -1,9 +1,9 @@
 (function (root) {
     "use strict";
 
-    var buster = root.buster || require("buster"),
-        sinon = root.sinon || require("../lib/sinon"),
-        assert = buster.assert;
+    var buster = root.buster || require("buster");
+    var sinon = root.sinon || require("../lib/sinon");
+    var assert = buster.assert;
 
     buster.testCase("sinon.typeOf", {
         "returns boolean": function () {

--- a/test/util/event-test.js
+++ b/test/util/event-test.js
@@ -1,9 +1,9 @@
 (function (root) {
     "use strict";
 
-    var buster = root.buster || require("buster"),
-        sinon = root.sinon || require("../../lib/sinon"),
-        assert = buster.assert;
+    var buster = root.buster || require("buster");
+    var sinon = root.sinon || require("../../lib/sinon");
+    var assert = buster.assert;
 
     buster.testCase("sinon.EventTarget", {
         setUp: function () {

--- a/test/util/fake-server-test.js
+++ b/test/util/fake-server-test.js
@@ -1,10 +1,10 @@
 (function (root) {
     "use strict";
 
-    var buster = root.buster || require("buster"),
-        sinon = root.sinon || require("../../lib/sinon"),
-        assert = buster.assert,
-        refute = buster.refute;
+    var buster = root.buster || require("buster");
+    var sinon = root.sinon || require("../../lib/sinon");
+    var assert = buster.assert;
+    var refute = buster.refute;
 
     // we need better ways to test both paths
     // but at least running tests in different environments will do that

--- a/test/util/fake-server-with-clock-test.js
+++ b/test/util/fake-server-with-clock-test.js
@@ -1,10 +1,10 @@
 (function (root) {
     "use strict";
 
-    var buster = root.buster || require("buster"),
-        sinon = root.sinon || require("../../lib/sinon"),
-        assert = buster.assert,
-        refute = buster.refute;
+    var buster = root.buster || require("buster");
+    var sinon = root.sinon || require("../../lib/sinon");
+    var assert = buster.assert;
+    var refute = buster.refute;
 
     buster.testCase("sinon.fakeServerWithClock", {
         requiresSupportFor: {

--- a/test/util/fake-timers-test.js
+++ b/test/util/fake-timers-test.js
@@ -1,11 +1,10 @@
 (function (root) {
     "use strict";
 
-    var buster = root.buster || require("buster"),
-        sinon = root.sinon || require("../../lib/sinon"),
-        assert = buster.assert,
-        refute = buster.refute;
-
+    var buster = root.buster || require("buster");
+    var sinon = root.sinon || require("../../lib/sinon");
+    var assert = buster.assert;
+    var refute = buster.refute;
     var GlobalDate = Date;
 
     buster.testCase("sinon.clock", {

--- a/test/util/fake-xdomain-request-test.js
+++ b/test/util/fake-xdomain-request-test.js
@@ -1,17 +1,14 @@
 (function (root) {
     "use strict";
 
-    var buster = root.buster || require("buster"),
-        sinon = root.sinon || require("../../lib/sinon"),
-        assert = buster.assert,
-        refute = buster.refute;
-
+    var buster = root.buster || require("buster");
+    var sinon = root.sinon || require("../../lib/sinon");
+    var assert = buster.assert;
+    var refute = buster.refute;
     var globalXDomainRequest = root.XDomainRequest;
-
     var fakeXdrSetUp = function () {
         this.fakeXdr = sinon.useFakeXDomainRequest();
     };
-
     var fakeXdrTearDown = function () {
         if (typeof this.fakeXdr.restore === "function") {
             this.fakeXdr.restore();

--- a/test/util/fake-xml-http-request-test.js
+++ b/test/util/fake-xml-http-request-test.js
@@ -1,10 +1,10 @@
 (function (root) {
     "use strict";
 
-    var buster = root.buster || require("buster"),
-        sinon = root.sinon || require("../../lib/sinon"),
-        assert = buster.assert,
-        refute = buster.refute;
+    var buster = root.buster || require("buster");
+    var sinon = root.sinon || require("../../lib/sinon");
+    var assert = buster.assert;
+    var refute = buster.refute;
 
     var globalXMLHttpRequest = root.XMLHttpRequest;
     var globalActiveXObject = root.ActiveXObject;
@@ -1230,8 +1230,8 @@
             },
 
             "updates attributes from working XHR object when ready state changes": function () {
-                var workingXHRInstance;
-                var readyStateCb;
+                var workingXHRInstance,
+                    readyStateCb;
                 var workingXHROverride = function () {
                     workingXHRInstance = this;
                     this.addEventListener = function (str, fn) {
@@ -1250,8 +1250,8 @@
             },
 
             "passes on methods to working XHR object": function () {
-                var workingXHRInstance;
-                var spy;
+                var workingXHRInstance,
+                    spy;
                 var workingXHROverride = function () {
                     workingXHRInstance = this;
                     this.addEventListener = this.open = function () {};
@@ -1266,8 +1266,8 @@
             },
 
             "calls legacy onreadystatechange handlers with target set to fakeXHR": function () {
-                var spy;
-                var readyStateCb;
+                var spy,
+                    readyStateCb;
                 var workingXHROverride = function () {
                     this.addEventListener = function (str, fn) {
                         readyStateCb = fn;
@@ -1671,8 +1671,8 @@
             },
 
             "fires events in an order similar to a browser": function (done) {
-                var xhr = this.xhr,
-                    events = [];
+                var xhr = this.xhr;
+                var events = [];
 
                 this.xhr.upload.addEventListener("progress", function (e) {
                     events.push(e.type);


### PR DESCRIPTION
This PR sets the ESLint `one-var` setting to be an error (2).

```javascript
"one-var": [2, {
    // Exactly one declaration for uninitialized variables per 
    // function (var) or block (let or const)
    "uninitialized": "always",
    // Exactly one declarator per initialized variable declaration
    // per function (var) or block (let or const)
    "initialized": "never"
}],
```

This means that correct formatting is as follows:

```javascript
var initialized1 = 1;
var initialized2 = 2;
var uninitialized1,
    uninitialized2;
```

I believe this matches @cjohansen's opinions on `var` declarations.

Fixes #807 