### PR TITLE
Add support for arraybuffer, blob responseTypes

### DIFF
--- a/lib/sinon/util/fake_xml_http_request.js
+++ b/lib/sinon/util/fake_xml_http_request.js
@@ -34,6 +34,8 @@
     var supportsProgress = typeof ProgressEvent !== "undefined";
     var supportsCustomEvent = typeof CustomEvent !== "undefined";
     var supportsFormData = typeof FormData !== "undefined";
+    var supportsArrayBuffer = typeof ArrayBuffer !== "undefined";
+    var supportsBlob = typeof Blob === "function";
     var sinonXhr = { XMLHttpRequest: global.XMLHttpRequest };
     sinonXhr.GlobalXMLHttpRequest = global.XMLHttpRequest;
     sinonXhr.GlobalActiveXObject = global.ActiveXObject;
@@ -288,19 +290,78 @@
         }
     }
 
-    FakeXMLHttpRequest.parseXML = function parseXML(text) {
-        var xmlDoc;
+    function convertToArrayBuffer(body) {
+        var buffer = new ArrayBuffer(body.length);
+        var view = new Uint8Array(buffer);
+        for (var i = 0; i < body.length; i++) {
+            var charCode = body.charCodeAt(i);
+            if (charCode >= 256) {
+                throw new TypeError("arraybuffer or blob responseTypes require binary string, " +
+                                    "invalid character " + body[i] + " found.");
+            }
+            view[i] = charCode;
+        }
+        return buffer;
+    }
 
-        if (typeof DOMParser !== "undefined") {
-            var parser = new DOMParser();
-            xmlDoc = parser.parseFromString(text, "text/xml");
+    function isXmlContentType(contentType) {
+        return !contentType || /(text\/xml)|(application\/xml)|(\+xml)/.test(contentType);
+    }
+
+    function convertResponseBody(responseType, contentType, body) {
+        if (responseType === "" || responseType === "text") {
+            return body;
+        } else if (supportsArrayBuffer && responseType === "arraybuffer") {
+            return convertToArrayBuffer(body);
+        } else if (responseType === "json") {
+            try {
+                return JSON.parse(body);
+            } catch (e) {
+                // Return parsing failure as null
+                return null;
+            }
+        } else if (supportsBlob && responseType === "blob") {
+            var blobOptions = {};
+            if (contentType) {
+                blobOptions.type = contentType;
+            }
+            return new Blob([convertToArrayBuffer(body)], blobOptions);
+        } else if (responseType === "document") {
+            if (isXmlContentType(contentType)) {
+                return FakeXMLHttpRequest.parseXML(body);
+            }
+            return null;
+        }
+        throw new Error("Invalid responseType " + responseType);
+    }
+
+    function clearResponse(xhr) {
+        if (xhr.responseType === "" || xhr.responseType === "text") {
+            xhr.response = xhr.responseText = "";
         } else {
-            xmlDoc = new window.ActiveXObject("Microsoft.XMLDOM");
-            xmlDoc.async = "false";
-            xmlDoc.loadXML(text);
+            xhr.response = xhr.responseText = null;
+        }
+        xhr.responseXML = null;
+    }
+
+    FakeXMLHttpRequest.parseXML = function parseXML(text) {
+        // Treat empty string as parsing failure
+        if (text !== "") {
+            try {
+                if (typeof DOMParser !== "undefined") {
+                    var parser = new DOMParser();
+                    return parser.parseFromString(text, "text/xml");
+                }
+                var xmlDoc = new window.ActiveXObject("Microsoft.XMLDOM");
+                xmlDoc.async = "false";
+                xmlDoc.loadXML(text);
+                return xmlDoc;
+            } catch (e) {
+                // Unable to parse XML - no biggie
+            }
         }
 
-        return xmlDoc;
+        return null;
     };
 
     FakeXMLHttpRequest.statusCodes = {
@@ -360,9 +421,7 @@
                 this.async = typeof async === "boolean" ? async : true;
                 this.username = username;
                 this.password = password;
-                this.responseText = null;
-                this.response = this.responseType === "json" ? null : "";
-                this.responseXML = null;
+                clearResponse(this);
                 this.requestHeaders = {};
                 this.sendFlag = false;
 
@@ -456,7 +515,7 @@
 
                 this.errorFlag = false;
                 this.sendFlag = this.async;
-                this.response = this.responseType === "json" ? null : "";
+                clearResponse(this);
                 this.readyStateChange(FakeXMLHttpRequest.OPENED);
 
                 if (typeof this.onSend === "function") {
@@ -468,8 +527,7 @@
 
             abort: function abort() {
                 this.aborted = true;
-                this.responseText = null;
-                this.response = this.responseType === "json" ? null : "";
+                clearResponse(this);
                 this.errorFlag = true;
                 this.requestHeaders = {};
                 this.responseHeaders = {};
@@ -525,32 +583,34 @@
                 verifyRequestSent(this);
                 verifyHeadersReceived(this);
                 verifyResponseBodyType(body);
+                var contentType = this.getResponseHeader("Content-Type");
 
-                var chunkSize = this.chunkSize || 10;
-                var index = 0;
-                this.responseText = "";
+                var isTextResponse = this.responseType === "" || this.responseType === "text";
+                clearResponse(this);
+                if (this.async) {
+                    var chunkSize = this.chunkSize || 10;
+                    var index = 0;
 
-                do {
-                    if (this.async) {
+                    do {
                         this.readyStateChange(FakeXMLHttpRequest.LOADING);
-                    }
 
-                    this.responseText += body.substring(index, index + chunkSize);
-                    index += chunkSize;
-                } while (index < body.length);
-
-                var type = this.getResponseHeader("Content-Type");
-
-                if (this.responseText &&
-                    (!type || /(text\/xml)|(application\/xml)|(\+xml)/.test(type))) {
-                    try {
-                        this.responseXML = FakeXMLHttpRequest.parseXML(this.responseText);
-                    } catch (e) {
-                        // Unable to parse XML - no biggie
-                    }
+                        if (isTextResponse) {
+                            this.responseText = this.response += body.substring(index, index + chunkSize);
+                        }
+                        index += chunkSize;
+                    } while (index < body.length);
                 }
 
-                this.response = this.responseType === "json" ? JSON.parse(this.responseText) : this.responseText;
+                this.response = convertResponseBody(this.responseType, contentType, body);
+                if (isTextResponse) {
+                    this.responseText = this.response;
+                }
+
+                if (this.responseType === "document") {
+                    this.responseXML = this.response;
+                } else if (this.responseType === "" && isXmlContentType(contentType)) {
+                    this.responseXML = FakeXMLHttpRequest.parseXML(this.responseText);
+                }
                 this.readyStateChange(FakeXMLHttpRequest.DONE);
             },
 

--- a/test/util/fake-xml-http-request-test.js
+++ b/test/util/fake-xml-http-request-test.js
@@ -36,7 +36,11 @@
 
     var assertArrayBufferMatches = function (actual, expected) {
         assert(actual instanceof ArrayBuffer, "${0} expected to be an ArrayBuffer");
-        var actualString = String.fromCharCode.apply(null, new Uint8Array(actual));
+        var actualString = "";
+        var actualView = new Uint8Array(actual);
+        for (var i = 0; i < actualView.length; i++) {
+            actualString += String.fromCharCode(actualView[i]);
+        }
         assert.same(actualString, expected, "ArrayBuffer [${0}] expected to match ArrayBuffer [${1}]");
     };
 

--- a/test/util/fake-xml-http-request-test.js
+++ b/test/util/fake-xml-http-request-test.js
@@ -11,6 +11,8 @@
 
     var supportsProgressEvents = typeof ProgressEvent !== "undefined";
     var supportsFormData = typeof FormData !== "undefined";
+    var supportsArrayBuffer = typeof ArrayBuffer !== "undefined";
+    var supportsBlob = typeof Blob === "function";
 
     var fakeXhrSetUp = function () {
         this.fakeXhr = sinon.useFakeXMLHttpRequest();
@@ -30,6 +32,20 @@
         } finally {
             sinon.xhr.workingXHR = original;
         }
+    };
+
+    var assertArrayBufferMatches = function (actual, expected) {
+        assert(actual instanceof ArrayBuffer, "${0} expected to be an ArrayBuffer");
+        var actualString = String.fromCharCode.apply(null, new Uint8Array(actual));
+        assert.same(actualString, expected, "ArrayBuffer [${0}] expected to match ArrayBuffer [${1}]");
+    };
+
+    var assertBlobMatches = function (actual, expected, done) {
+        var actualReader = new FileReader();
+        actualReader.onloadend = done(function () {
+            assert.same(actualReader.result, expected);
+        });
+        actualReader.readAsBinaryString(actual);
     };
 
     buster.testCase("sinon.FakeXMLHttpRequest", {
@@ -115,10 +131,22 @@
                 assert.isFalse(this.xhr.async);
             },
 
-            "sets responseText to null": function () {
+            "sets response to empty string": function () {
                 this.xhr.open("GET", "/my/url");
 
-                assert.isNull(this.xhr.responseText);
+                assert.same(this.xhr.response, "");
+            },
+
+            "sets responseText to empty string": function () {
+                this.xhr.open("GET", "/my/url");
+
+                assert.same(this.xhr.responseText, "");
+            },
+
+            "sets responseXML to null": function () {
+                this.xhr.open("GET", "/my/url");
+
+                assert.isNull(this.xhr.responseXML);
             },
 
             "sets requestHeaders to blank object": function () {
@@ -154,7 +182,9 @@
                 assert.isTrue(state.async);
                 refute.defined(state.username);
                 refute.defined(state.password);
-                assert.isNull(state.responseText);
+                assert.same(state.response, "");
+                assert.same(state.responseText, "");
+                assert.isNull(state.responseXML);
                 refute.defined(state.responseHeaders);
                 assert.equals(state.readyState, sinon.FakeXMLHttpRequest.OPENED);
                 assert.isFalse(state.sendFlag);
@@ -549,16 +579,19 @@
 
             "invokes onreadystatechange handler with partial data": function () {
                 var pieces = [];
+                var mismatch = false;
 
-                var spy = sinon.spy(function () {
+                this.xhr.readyStateChange = function () {
+                    if (this.response !== this.responseText) {
+                        mismatch = true;
+                    }
                     pieces.push(this.responseText);
-                });
-
-                this.xhr.readyStateChange = spy;
+                };
                 this.xhr.chunkSize = 9;
 
                 this.xhr.setResponseBody("Some text goes in here ok?");
 
+                assert.isFalse(mismatch);
                 assert.equals(pieces[1], "Some text");
             },
 
@@ -610,6 +643,42 @@
                 assert.exception(function () {
                     xhr.setResponseBody({});
                 }, "InvalidBodyException");
+            },
+
+            "with ArrayBuffer support": {
+                requiresSupportFor: {
+                    "ArrayBuffer": supportsArrayBuffer
+                },
+
+                "invokes onreadystatechange for each chunk when responseType='arraybuffer'": function () {
+                    var spy = sinon.spy();
+                    this.xhr.readyStateChange = spy;
+                    this.xhr.chunkSize = 10;
+
+                    this.xhr.responseType = "arraybuffer";
+
+                    this.xhr.setResponseBody("Some text goes in here ok?");
+
+                    assert.equals(spy.callCount, 4);
+                }
+            },
+
+            "with Blob support": {
+                requiresSupportFor: {
+                    "Blob": supportsBlob
+                },
+
+                "invokes onreadystatechange handler for each 10 byte chunk when responseType='blob'": function () {
+                    var spy = sinon.spy();
+                    this.xhr.readyStateChange = spy;
+                    this.xhr.chunkSize = 10;
+
+                    this.xhr.responseType = "blob";
+
+                    this.xhr.setResponseBody("Some text goes in here ok?");
+
+                    assert.equals(spy.callCount, 4);
+                }
             }
         },
 
@@ -887,12 +956,20 @@
                 assert.isTrue(this.xhr.aborted);
             },
 
-            "sets responseText to null": function () {
+            "sets response to empty string": function () {
                 this.xhr.responseText = "Partial data";
 
                 this.xhr.abort();
 
-                assert.isNull(this.xhr.responseText);
+                assert.same(this.xhr.response, "");
+            },
+
+            "sets responseText to empty string": function () {
+                this.xhr.responseText = "Partial data";
+
+                this.xhr.abort();
+
+                assert.same(this.xhr.responseText, "");
             },
 
             "sets errorFlag to true": function () {
@@ -1003,15 +1080,26 @@
                 this.xhr = new sinon.FakeXMLHttpRequest();
             },
 
-            "is initially the empty string if responseType !== 'json'": function () {
-                this.xhr.responseType = "arraybuffer";
+            "is initially the empty string if responseType === ''": function () {
+                this.xhr.responseType = "";
                 this.xhr.open("GET", "/");
-                assert.isString(this.xhr.response);
-                assert.equals(this.xhr.response, "");
+                assert.same(this.xhr.response, "");
+            },
+
+            "is initially the empty string if responseType === 'text'": function () {
+                this.xhr.responseType = "text";
+                this.xhr.open("GET", "/");
+                assert.same(this.xhr.response, "");
             },
 
             "is initially null if responseType === 'json'": function () {
                 this.xhr.responseType = "json";
+                this.xhr.open("GET", "/");
+                assert.isNull(this.xhr.response);
+            },
+
+            "is initially null if responseType === 'document'": function () {
+                this.xhr.responseType = "document";
                 this.xhr.open("GET", "/");
                 assert.isNull(this.xhr.response);
             },
@@ -1022,8 +1110,7 @@
 
                 this.xhr.respond(200, {}, "");
 
-                assert.isString(this.xhr.response);
-                assert.equals(this.xhr.response, "");
+                assert.same(this.xhr.response, "");
             },
 
             "parses JSON for responseType='json'": function () {
@@ -1051,6 +1138,89 @@
                 var response = this.xhr.response;
                 assert.isString(response);
                 assert.equals(response, responseText);
+            },
+
+            "with ArrayBuffer support": {
+                requiresSupportFor: {
+                    "ArrayBuffer": supportsArrayBuffer
+                },
+
+                "is initially null if responseType === 'arraybuffer'": function () {
+                    this.xhr.responseType = "arraybuffer";
+                    this.xhr.open("GET", "/");
+                    assert.isNull(this.xhr.response);
+                },
+
+                "defaults to empty ArrayBuffer response": function () {
+                    this.xhr.responseType = "arraybuffer";
+                    this.xhr.open("GET", "/");
+                    this.xhr.send();
+
+                    this.xhr.respond();
+                    assertArrayBufferMatches(this.xhr.response, "");
+                },
+
+                "returns ArrayBuffer when responseType='arraybuffer'": function () {
+                    this.xhr.responseType = "arraybuffer";
+                    this.xhr.open("GET", "/");
+                    this.xhr.send();
+
+                    this.xhr.respond(200, { "Content-Type": "application/octet-stream" }, "a test buffer");
+
+                    assertArrayBufferMatches(this.xhr.response, "a test buffer");
+                },
+
+                "returns binary data correctly when responseType='arraybuffer'": function () {
+                    this.xhr.responseType = "arraybuffer";
+                    this.xhr.open("GET", "/");
+                    this.xhr.send();
+
+                    this.xhr.respond(200, { "Content-Type": "application/octet-stream" }, "\xFF");
+
+                    assertArrayBufferMatches(this.xhr.response, "\xFF");
+                }
+            },
+
+            "with Blob support": {
+                requiresSupportFor: {
+                    "Blob": supportsBlob
+                },
+
+                "is initially null if responseType === 'blob'": function () {
+                    this.xhr.responseType = "blob";
+                    this.xhr.open("GET", "/");
+                    assert.isNull(this.xhr.response);
+                },
+
+                "defaults to empty Blob response": function (done) {
+                    this.xhr.responseType = "blob";
+                    this.xhr.open("GET", "/");
+                    this.xhr.send();
+
+                    this.xhr.respond();
+
+                    assertBlobMatches(this.xhr.response, "", done);
+                },
+
+                "returns blob with correct data": function (done) {
+                    this.xhr.responseType = "blob";
+                    this.xhr.open("GET", "/");
+                    this.xhr.send();
+
+                    this.xhr.respond(200, { "Content-Type": "application/octet-stream" }, "a test blob");
+
+                    assertBlobMatches(this.xhr.response, "a test blob", done);
+                },
+
+                "returns blob with correct binary data": function (done) {
+                    this.xhr.responseType = "blob";
+                    this.xhr.open("GET", "/");
+                    this.xhr.send();
+
+                    this.xhr.respond(200, { "Content-Type": "application/octet-stream" }, "\xFF");
+
+                    assertBlobMatches(this.xhr.response, "\xFF", done);
+                }
             }
         },
 


### PR DESCRIPTION
Based on spec: http://www.w3.org/TR/XMLHttpRequest/

Binary response types (`arraybuffer`, `blob`) expect binary strings (strings with `charCode`s in the range `0x00`-`0xFF`) in place of normal strings.

Align slightly more closely to spec (e.g. `responseText` should be `""`, not `null` when opening an XHR of `text` or unspecified `responseType`; `responseXML` should only be populated when `responseType` is `""` or `"document"`, etc.).

Does not support browsers that only implement the `BlobBuilder` API (like PhantomJS 1.9.x).