### PR TITLE
Fixed async tests that had async bits commented out

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   },
   "devDependencies": {
     "buster": "0.7.18",
+    "buster-core": "^0.6.4",
     "buster-istanbul": "0.1.13",
     "eslint": "0.24.0",
     "eslint-config-defaults": "^2.1.0",

--- a/test/test-test.js
+++ b/test/test-test.js
@@ -2,6 +2,7 @@
     "use strict";
 
     var buster = root.buster || require("buster");
+    var nextTick = buster.nextTick || require("buster-core").nextTick;
     var sinon = root.sinon || require("../lib/sinon");
     var assert = buster.assert;
     var refute = buster.refute;
@@ -128,10 +129,9 @@
             };
 
             sinon.test(function (callback) {
-                // FIXME: Why does this not finish in node but works fine in browsers?
-                // buster.nextTick(function () {
-                callback();
-                // });
+                nextTick(function () {
+                    callback();
+                });
             }).call({}, fakeDone);
         },
 
@@ -147,11 +147,30 @@
                     fn.call(this);
                 }
             };
+
             it("works", sinon.test(function (callback) {
-                // FIXME: Why does this not finish in node but works fine in browsers?
-                // buster.nextTick(function () {
+                nextTick(function () {
+                    callback();
+                });
+            }));
+
+        },
+
+        "async test with sandbox using mocha interface throwing error": function (done) {
+            var it = function (title, fn) {
+                var mochaDone = function (args) {
+                    assert.equals(args, undefined);
+                    done(args);
+                };
+                if (fn.length) {
+                    fn.call(this, mochaDone);
+                } else {
+                    fn.call(this);
+                }
+            };
+
+            it("works", sinon.test(function (callback) {
                 callback();
-                // });
             }));
         },
 
@@ -168,12 +187,11 @@
                 var addOneInnerSpy = this.spy();
                 this.stub(globalObj, "addOneInner", addOneInnerSpy);
 
-                // FIXME: Why does this not finish in node but works fine in browsers?
-                // buster.nextTick(function () {
-                globalObj.addOne(41);
-                assert(addOneInnerSpy.calledOnce);
-                callback();
-                // });
+                nextTick(function () {
+                    globalObj.addOne(41);
+                    assert(addOneInnerSpy.calledOnce);
+                    callback();
+                });
             }).call({}, done);
         },
 


### PR DESCRIPTION
These tests were expecting buster to have been extended with the utils from buster-core, but this failed on Node, but since the failing require() call exception was swallowed by the buster test runner it was hard to debug why.

Explicitly requiring buster-core fixes the problem.

Related to #702