### PR TITLE
Fix for issue 818

### DIFF
--- a/lib/sinon/test.js
+++ b/lib/sinon/test.js
@@ -35,7 +35,6 @@
                     args[args.length - 1] = function sinonDone(res) {
                         if (res) {
                             sandbox.restore();
-                            throw exception;
                         } else {
                             sandbox.verifyAndRestore();
                         }

--- a/test/test-test.js
+++ b/test/test-test.js
@@ -122,6 +122,21 @@
             }).call({});
         },
 
+        "passes on errors to callbacks": function () {
+
+            var fn = sinon.test(function (callback) {
+                callback(new Error("myerror"));
+            });
+
+            function errorChecker(err) {
+                errorChecker.called = true;
+                assert.equals(err instanceof Error, true);
+            }
+
+            fn(errorChecker);
+            assert.equals(errorChecker.called, true);
+        },
+
         "async test with sandbox": function (done) {
             var fakeDone = function (args) {
                 assert.equals(args, undefined);


### PR DESCRIPTION
Issue #818 makes SinonJS break async mocha tests. After examining the sinon code, I am assuming duplicated code led to some invalid logic where the exception was thrown, rather than being passed on to the callback. This PR fixes issue #818 while is seems not to break anything else. 