### PR TITLE
sinon.logError.useImmediateExceptions

### DIFF
--- a/lib/sinon/log_error.js
+++ b/lib/sinon/log_error.js
@@ -24,17 +24,27 @@
         function logError(label, err) {
             var msg = label + " threw exception: ";
 
+            function throwLoggedError() {
+                err.message = msg + err.message;
+                throw err;
+            }
+
             sinon.log(msg + "[" + err.name + "] " + err.message);
 
             if (err.stack) {
                 sinon.log(err.stack);
             }
 
-            logError.setTimeout(function () {
-                err.message = msg + err.message;
-                throw err;
-            }, 0);
+            if (logError.useImmediateExceptions) {
+                throwLoggedError();
+            } else {
+                logError.setTimeout(throwLoggedError, 0);
+            }
         }
+
+        // When set to true, any errors logged will be thrown immediately;
+        // If set to false, the errors will be thrown in separate execution frame.
+        logError.useImmediateExceptions = false;
 
         // wrap realSetTimeout with something we can stub in tests
         logError.setTimeout = function (func, timeout) {

--- a/test/log-error-test.js
+++ b/test/log-error-test.js
@@ -4,6 +4,7 @@
     var buster = root.buster || require("buster");
     var sinon = root.sinon || require("../lib/sinon");
     var assert = buster.assert;
+    var refute = buster.refute;
 
     buster.testCase("sinon.log", {
         "is a function": function () {
@@ -70,6 +71,43 @@
 
             var func = this.timeOutStub.args[0][0];
             assert.exception(func);
+        }
+    });
+
+    buster.testCase("sinon.logError.useImmediateExceptions", {
+        setUp: function () {
+            this.sandbox = sinon.sandbox.create();
+            this.timeOutStub = this.sandbox.stub(sinon.logError, "setTimeout");
+            this.originalFlag = sinon.logError.useImmediateExceptions;
+        },
+
+        tearDown: function () {
+            // setTimeout = realSetTimeout;
+            this.sandbox.restore();
+            sinon.logError.useImmediateExceptions = this.originalFlag;
+        },
+
+        "throws the logged error immediately, does not call logError.setTimeout when flag is true": function () {
+
+            var error = new Error();
+
+            sinon.logError.useImmediateExceptions = true;
+
+            assert.exception(function () {
+                sinon.logError("an error", error);
+            });
+            assert(this.timeOutStub.notCalled);
+        },
+
+        "does not throw logged error immediately and calls logError.setTimeout when flag is false": function () {
+            var error = new Error();
+
+            sinon.logError.useImmediateExceptions = false;
+
+            refute.exception(function () {
+                sinon.logError("an error", error);
+            });
+            assert(this.timeOutStub.called);
         }
     });
 }(this));


### PR DESCRIPTION
Implementation of idea proposed in #172, a flag on `sinon.logError` that, when set to true, makes the method throw the errors in the same execution frame, thus allowing for easier debugging and/or better handling in test cases that deal with XHR requests.