### PR TITLE
Updated fake-server tests to test what the descriptions proclaim

### DIFF
--- a/test/util/fake-server-test.js
+++ b/test/util/fake-server-test.js
@@ -38,28 +38,29 @@
             },
             "allows the 'autoRespondAfter' setting": function () {
                 var server = sinon.fakeServer.create({
-                    autoRespond: true
+                    autoRespondAfter: 500
                 });
-                assert(
-                    server.autoRespond,
+                assert.equals(
+                    server.autoRespondAfter,
+                    500,
                     "fakeServer.create should accept 'autoRespondAfter' setting"
                 );
             },
             "allows the 'respondImmediately' setting": function () {
                 var server = sinon.fakeServer.create({
-                    autoRespond: true
+                    respondImmediately: true
                 });
                 assert(
-                    server.autoRespond,
+                    server.respondImmediately,
                     "fakeServer.create should accept 'respondImmediately' setting"
                 );
             },
             "allows the 'fakeHTTPMethods' setting": function () {
                 var server = sinon.fakeServer.create({
-                    autoRespond: true
+                    fakeHTTPMethods: true
                 });
                 assert(
-                    server.autoRespond,
+                    server.fakeHTTPMethods,
                     "fakeServer.create should accept 'fakeHTTPMethods' setting"
                 );
             },


### PR DESCRIPTION
The tests in 0f05ba905a6e495aa1859a37e9c2d83a366c7a58 were erraneously copy and pasted. They say they are testing X, but they test Y. I fixed the tests to match what they proclaim to test.