### PR TITLE
Fix #821 where Sinon.JS would leak a setImmdiate into global scope

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "formatio": "1.1.1",
     "util": ">=0.10.3 <1",
-    "lolex": "1.3.1",
+    "lolex": "1.3.2",
     "samsam": "1.1.2"
   },
   "devDependencies": {


### PR DESCRIPTION
This would break some setImmediate polyfills as documented in https://github.com/sinonjs/lolex/pull/26

This PR updates Sinon.JS to use `lolex@1.3.2`, which has a fix for #821 